### PR TITLE
Issue #8 - Mark an item on my shopping list as purchased

### DIFF
--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -32,16 +32,18 @@ export default function List(props) {
           <span>Your Shopping List:</span>
           <ul>
             {listItem.docs.map((doc) => (
-              <div className="checkbox-wrapper">
-                <input
-                  type="checkbox"
-                  defaultChecked={
-                    compareTimeStamps(doc.data().last_purchased) ? true : false
-                  }
-                  onClick={(e) => markItemPurchased(e, doc.id)}
-                />
-                <li key={doc.id}>{doc.data().item_name}</li>
-              </div>
+              <li key={doc.id} className="checkbox-wrapper">
+                <label>
+                  <input
+                    type="checkbox"
+                    defaultChecked={compareTimeStamps(
+                      doc.data().last_purchased,
+                    )}
+                    onClick={(e) => markItemPurchased(e, doc.id)}
+                  />
+                  {doc.data().item_name}
+                </label>
+              </li>
             ))}
           </ul>
         </>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -7,20 +7,28 @@ export default function List(props) {
   });
 
   const markItemPurchased = (e, id) => {
-    const timeElapsed = Date.now();
-    const today = new Date(timeElapsed);
+    const elapsedMilliseconds = Date.now();
 
     if (e.target.checked === true) {
       db.collection(props.token).doc(id).update({
-        last_purchased: today.toUTCString(),
+        last_purchased: elapsedMilliseconds,
+      });
+    } else {
+      db.collection(props.token).doc(id).update({
+        last_purchased: null,
       });
     }
   };
 
+  function compareTimeStamps(lastPurchased) {
+    const currentElapsedMilliseconds = Date.now();
+    const millisecondsInOneDay = 86400000;
+    return currentElapsedMilliseconds - lastPurchased < millisecondsInOneDay;
+  }
+
   return (
     <>
-      <h1>THIS IS THE LIST</h1>
-      <h2>Your token: {props.token}</h2>
+      <h1>Your token: {props.token}</h1>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Collection: Loading...</span>}
       {listItem && (
@@ -31,6 +39,9 @@ export default function List(props) {
               <div className="checkbox-wrapper">
                 <input
                   type="checkbox"
+                  defaultChecked={
+                    compareTimeStamps(doc.data().last_purchased) ? true : false
+                  }
                   onClick={(e) => markItemPurchased(e, doc.id)}
                 />
                 <li key={doc.id}>{doc.data().item_name}</li>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -13,10 +13,13 @@ export default function List(props) {
       {loading && <span>Collection: Loading...</span>}
       {listItem && (
         <>
-          <span>Collection:</span>
+          <span>Your Shopping List:</span>
           <ul>
             {listItem.docs.map((doc) => (
-              <li key={doc.id}>{doc.data().item_name}</li>
+              <div className="checkbox-wrapper">
+                <input type="checkbox"></input>
+                <li key={doc.id}>{doc.data().item_name}</li>
+              </div>
             ))}
           </ul>
         </>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -13,10 +13,6 @@ export default function List(props) {
       db.collection(props.token).doc(id).update({
         last_purchased: elapsedMilliseconds,
       });
-    } else {
-      db.collection(props.token).doc(id).update({
-        last_purchased: null,
-      });
     }
   };
 

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -39,6 +39,7 @@ export default function List(props) {
                     defaultChecked={compareTimeStamps(
                       doc.data().last_purchased,
                     )}
+                    disabled={compareTimeStamps(doc.data().last_purchased)}
                     onClick={(e) => markItemPurchased(e, doc.id)}
                   />
                   {doc.data().item_name}

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -16,7 +16,7 @@ export default function List(props) {
           <span>Collection:</span>
           <ul>
             {listItem.docs.map((doc) => (
-              <li key={doc.id}>{JSON.stringify(doc.data())}</li>
+              <li key={doc.id}>{doc.data().item_name}</li>
             ))}
           </ul>
         </>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -6,13 +6,16 @@ export default function List(props) {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
 
-  const markItemPurchased = (id) => {
-    db.collection(props.token).doc(id).update({
-      last_purchased: Date.now(),
-    });
-  };
+  const markItemPurchased = (e, id) => {
+    const timeElapsed = Date.now();
+    const today = new Date(timeElapsed);
 
-  console.log(listItem);
+    if (e.target.checked === true) {
+      db.collection(props.token).doc(id).update({
+        last_purchased: today.toUTCString(),
+      });
+    }
+  };
 
   return (
     <>
@@ -24,20 +27,15 @@ export default function List(props) {
         <>
           <span>Your Shopping List:</span>
           <ul>
-            {listItem.docs.map(
-              (doc) => (
-                console.log(doc.id),
-                (
-                  <div className="checkbox-wrapper">
-                    <input
-                      type="checkbox"
-                      onClick={markItemPurchased(doc.id)}
-                    />
-                    <li key={doc.id}>{doc.data().item_name}</li>
-                  </div>
-                )
-              ),
-            )}
+            {listItem.docs.map((doc) => (
+              <div className="checkbox-wrapper">
+                <input
+                  type="checkbox"
+                  onClick={(e) => markItemPurchased(e, doc.id)}
+                />
+                <li key={doc.id}>{doc.data().item_name}</li>
+              </div>
+            ))}
           </ul>
         </>
       )}

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -5,6 +5,15 @@ export default function List(props) {
   const [listItem, loading, error] = useCollection(db.collection(props.token), {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
+
+  const markItemPurchased = (id) => {
+    db.collection(props.token).doc(id).update({
+      last_purchased: Date.now(),
+    });
+  };
+
+  console.log(listItem);
+
   return (
     <>
       <h1>THIS IS THE LIST</h1>
@@ -15,12 +24,20 @@ export default function List(props) {
         <>
           <span>Your Shopping List:</span>
           <ul>
-            {listItem.docs.map((doc) => (
-              <div className="checkbox-wrapper">
-                <input type="checkbox"></input>
-                <li key={doc.id}>{doc.data().item_name}</li>
-              </div>
-            ))}
+            {listItem.docs.map(
+              (doc) => (
+                console.log(doc.id),
+                (
+                  <div className="checkbox-wrapper">
+                    <input
+                      type="checkbox"
+                      onClick={markItemPurchased(doc.id)}
+                    />
+                    <li key={doc.id}>{doc.data().item_name}</li>
+                  </div>
+                )
+              ),
+            )}
           </ul>
         </>
       )}

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -28,3 +28,14 @@
 .nav-link-bold {
   font-weight: bold;
 }
+
+.checkbox-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+li {
+  list-style-type: none;
+  margin-left: 0.5rem;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Description

This PR updates the List view which was previously displaying the information straight from the JSON file. The list items are now showing individual list items with a checkbox that can be used to mark purchased items.

## Related Issue

closes #9 

## Acceptance Criteria

- [x]  User is able to tap a checkbox or similar UI element to mark an item in the list as purchased
- [x]  Item should be shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day)


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<img width="572" alt="Screen Shot 2021-04-26 at 7 35 34 PM" src="https://user-images.githubusercontent.com/20430736/116159417-93e62100-a6c6-11eb-875f-abc295a0462d.png">

https://user-images.githubusercontent.com/47455758/116334400-c2cdc700-a79a-11eb-8571-0fd94d637b0f.mp4


### After
<img width="554" alt="Screen Shot 2021-04-26 at 7 36 30 PM" src="https://user-images.githubusercontent.com/20430736/116159489-b6783a00-a6c6-11eb-8fe8-d789d100b712.png">

https://user-images.githubusercontent.com/47455758/116334417-ca8d6b80-a79a-11eb-8208-274f98e64c55.mp4


## Testing Steps / QA Criteria

1. run `git checkout jc-ar-mark-items-purchased`
2. run `npm install`
3. run `npm start`
4. If you need to enter a token, you can use `sire agnew dutch`
5. If a checkbox is checked blue already, that means it was marked purchased less than 24 hours prior. Check any boxes that are unchecked, and uncheck any boxes that are checked. Hit refresh and they will each maintain their checked or unchecked stats.
6. If you add a new item, you will see that the checkbox is initially unchecked.

## Notes

- I feel great about how we completed the AC!
- One thing that was not clear in the AC was how to handle if the user wants the item unchecked less than 24 hours.
   - We decided to allow the user to uncheck a checkbox that is still less than 24 hours old. What if they accidentally marked it as purchased? Or what if they realize they need MORE milk for breakfast tomorrow?
   - So when the item is marked as purchased, the checkbox remains checked for 24 hours, BUT if the user unchecks it, we update Firestore with last_purchased: null again.
- If I'm being honest, I initially over-complicated the issue, but then I found some incredibly simple solutions for functionality I thought was going to be difficult! For example:

```javascript
function compareTimeStamps(lastPurchased) {
  const currentElapsedMilliseconds = Date.now();
  const millisecondsInOneDay = 86400000;
  return currentElapsedMilliseconds - lastPurchased < millisecondsInOneDay;
}
...
<ul>
  {listItem.docs.map((doc) => (
    <div className="checkbox-wrapper">
      <input
        type="checkbox"
        defaultChecked={
          compareTimeStamps(doc.data().last_purchased) ? true : false
         }
         onClick={(e) => markItemPurchased(e, doc.id)}
       />
      <li key={doc.id}>{doc.data().item_name}</li>
    </div>
  ))}
</ul>
```
  - The `defaultChecked` property for an `<input type="checkbox" />` is so simple and elegant!
  - We created a function `compareTimeStamps(lastPurchased)` that we call inside the `defaultChecked` property. We pass in the `doc.data().last_purchased` to `compareTimeStamps(lastPurchased)` and that checks if the `.last_purchased` property is less than 24 hours (or 86,400,00 milliseconds) from the current moment the List.js component mounts, `const currentElapsedMilliseconds = Date.now()`. This returns to us a `true` or `false` boolean that dictates whether the checkbox is checked or not, even on page reload.

## Updates

- After our mid-week meeting, we decided NOT to send a `last_purchased: null` back to Firestore when an item is unchecked. We will have decisions to make in a later story, issue 10, where we decide how to keep track of multiple timestamps to be able to compare and calculate average purchase frequency. 

That said, I removed lines 16-19:
```javascript
} else {
  db.collection(props.token).doc(id).update({
    last_purchased: null,
  });
```