### PR TITLE
useCollection for downstream data instead of .get()/useEffect()

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,12 +17,20 @@ const App = () => {
     setToken(retrievedToken);
   }, []);
 
+  // Comment out lines 21-26 and Un-comment lines 28-33. It won't accept the `token`
   const [listItems, loading, error] = useCollection(
-    db.collection('sire agnew dutch'),
+    db.collection(`'sire agnew dutch'`),
     {
       snapshotListenOptions: { includeMetadataChanges: true },
     },
   );
+
+  // const [listItems, loading, error] = useCollection(
+  //   db.collection(token),
+  //   {
+  //     snapshotListenOptions: { includeMetadataChanges: true },
+  //   },
+  // );
 
   return (
     <Router>

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { db } from './lib/firebase';
-import { useCollection } from 'react-firebase-hooks/firestore';
 import { checkLocalStorageForKey } from './lib/localStorage';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import './stylesheets/App.css';
@@ -16,18 +14,6 @@ const App = () => {
     const retrievedToken = checkLocalStorageForKey('token', '');
     setToken(retrievedToken);
   }, []);
-
-  // Comment out lines 21-26 and Un-comment lines 28-33. It won't accept the `token`
-  // const [listItems, loading, error] = useCollection(
-  //   db.collection('sire agnew dutch'),
-  //   {
-  //     snapshotListenOptions: { includeMetadataChanges: true },
-  //   },
-  // );
-
-  // const [listItems, loading, error] = useCollection(db.collection(token), {
-  //   snapshotListenOptions: { includeMetadataChanges: true },
-  // });
 
   return (
     <Router>

--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ const App = () => {
 
   // Comment out lines 21-26 and Un-comment lines 28-33. It won't accept the `token`
   const [listItems, loading, error] = useCollection(
-    db.collection(`'sire agnew dutch'`),
+    db.collection('sire agnew dutch'),
     {
       snapshotListenOptions: { includeMetadataChanges: true },
     },

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { db } from './lib/firebase';
+import { useCollection } from 'react-firebase-hooks/firestore';
 import { checkLocalStorageForKey } from './lib/localStorage';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import './stylesheets/App.css';
@@ -10,27 +11,18 @@ import AddItem from './pages/AddItem';
 
 const App = () => {
   const [token, setToken] = useState('');
-  const [listItems, setListItems] = useState([]);
 
   useEffect(() => {
     const retrievedToken = checkLocalStorageForKey('token', '');
     setToken(retrievedToken);
   }, []);
 
-  useEffect(() => {
-    if (token) {
-      db.collection(token)
-        .get()
-        .then((querySnapshot) => {
-          const listItemData = [];
-
-          querySnapshot.forEach((doc) => {
-            listItemData.push(doc.data());
-          });
-          setListItems(listItemData);
-        });
-    }
-  }, [token]);
+  const [listItems, loading, error] = useCollection(
+    db.collection('sire agnew dutch'),
+    {
+      snapshotListenOptions: { includeMetadataChanges: true },
+    },
+  );
 
   return (
     <Router>
@@ -43,14 +35,15 @@ const App = () => {
                 <List token={token} />
               </Route>
               <Route exact path="/list">
-                <List token={token} />
+                <List
+                  token={token}
+                  listItems={listItems}
+                  loading={loading}
+                  error={error}
+                />
               </Route>
               <Route exact path="/add-item">
-                <AddItem
-                  listItems={listItems}
-                  setListItems={setListItems}
-                  token={token}
-                />
+                <AddItem listItems={listItems} token={token} />
               </Route>
             </Switch>
           </>

--- a/src/App.js
+++ b/src/App.js
@@ -18,19 +18,16 @@ const App = () => {
   }, []);
 
   // Comment out lines 21-26 and Un-comment lines 28-33. It won't accept the `token`
-  const [listItems, loading, error] = useCollection(
-    db.collection('sire agnew dutch'),
-    {
-      snapshotListenOptions: { includeMetadataChanges: true },
-    },
-  );
-
   // const [listItems, loading, error] = useCollection(
-  //   db.collection(token),
+  //   db.collection('sire agnew dutch'),
   //   {
   //     snapshotListenOptions: { includeMetadataChanges: true },
   //   },
   // );
+
+  // const [listItems, loading, error] = useCollection(db.collection(token), {
+  //   snapshotListenOptions: { includeMetadataChanges: true },
+  // });
 
   return (
     <Router>
@@ -43,15 +40,10 @@ const App = () => {
                 <List token={token} />
               </Route>
               <Route exact path="/list">
-                <List
-                  token={token}
-                  listItems={listItems}
-                  loading={loading}
-                  error={error}
-                />
+                <List token={token} />
               </Route>
               <Route exact path="/add-item">
-                <AddItem listItems={listItems} token={token} />
+                <AddItem token={token} />
               </Route>
             </Switch>
           </>

--- a/src/lib/estimates.js
+++ b/src/lib/estimates.js
@@ -9,17 +9,17 @@
  * @return {Number} Estimated number of days until the next purchase
  */
 const calculateEstimate = (lastEstimate, latestInterval, numberOfPurchases) => {
-    if (numberOfPurchases >= 2) {
-        if (isNaN(lastEstimate)) {
-            lastEstimate = 14;
-        }
-        let previousFactor = lastEstimate * numberOfPurchases;
-        let latestFactor = latestInterval * (numberOfPurchases - 1);
-        let totalDivisor = numberOfPurchases * 2 - 1;
-        return Math.round((previousFactor + latestFactor) / totalDivisor);
-    } else {
-        return latestInterval;
+  if (numberOfPurchases >= 2) {
+    if (isNaN(lastEstimate)) {
+      lastEstimate = 14;
     }
+    let previousFactor = lastEstimate * numberOfPurchases;
+    let latestFactor = latestInterval * (numberOfPurchases - 1);
+    let totalDivisor = numberOfPurchases * 2 - 1;
+    return Math.round((previousFactor + latestFactor) / totalDivisor);
+  } else {
+    return latestInterval;
+  }
 };
 
 export default calculateEstimate;

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -9,7 +9,7 @@ export default function AddItem({ token }) {
   const [purchaseFrequency, setPurchaseFrequency] = useState(7);
   const [lastPurchased] = useState(null);
 
-  const [listItems, loading, error] = useCollection(db.collection(token), {
+  const [listItems] = useCollection(db.collection(token), {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
 

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -3,7 +3,7 @@ import { db } from '../lib/firebase';
 import swal from 'sweetalert';
 import { useHistory } from 'react-router-dom';
 
-export default function AddItem(props) {
+export default function AddItem({ listItems, token }) {
   const [itemName, setItemName] = useState('');
   const [purchaseFrequency, setPurchaseFrequency] = useState(7);
   const [lastPurchased] = useState(null);
@@ -23,10 +23,11 @@ export default function AddItem(props) {
   };
 
   const doesItemExistInDatabase = () => {
+    console.log(itemName);
     const normalizedUserInput = normalizeString(itemName);
 
-    const matchingItemName = props.listItems.filter((item) => {
-      const normalizedDatabaseItem = normalizeString(item.item_name);
+    const matchingItemName = listItems.docs.filter((doc) => {
+      const normalizedDatabaseItem = normalizeString(doc.data().item_name);
 
       return normalizedDatabaseItem === normalizedUserInput;
     });
@@ -54,8 +55,7 @@ export default function AddItem(props) {
     } else if (!itemName) {
       swal('UH OH!', "Item name can't be blank", 'warning');
     } else {
-      db.collection(props.token).add(newItemObject);
-      props.setListItems((prev) => [...prev, newItemObject]);
+      db.collection(token).add(newItemObject);
       history.push('/list');
     }
   }

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 import { db } from '../lib/firebase';
+import { useCollection } from 'react-firebase-hooks/firestore';
 import swal from 'sweetalert';
 import { useHistory } from 'react-router-dom';
 
-export default function AddItem({ listItems, token }) {
+export default function AddItem({ token }) {
   const [itemName, setItemName] = useState('');
   const [purchaseFrequency, setPurchaseFrequency] = useState(7);
   const [lastPurchased] = useState(null);
+
+  const [listItems, loading, error] = useCollection(db.collection(token), {
+    snapshotListenOptions: { includeMetadataChanges: true },
+  });
 
   const history = useHistory();
 
@@ -23,7 +28,6 @@ export default function AddItem({ listItems, token }) {
   };
 
   const doesItemExistInDatabase = () => {
-    console.log(itemName);
     const normalizedUserInput = normalizeString(itemName);
 
     const matchingItemName = listItems.docs.filter((doc) => {

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -1,16 +1,11 @@
 import { db } from '../lib/firebase';
-import { useCollection } from 'react-firebase-hooks/firestore';
 
-export default function List(props) {
-  const [listItem, loading, error] = useCollection(db.collection(props.token), {
-    snapshotListenOptions: { includeMetadataChanges: true },
-  });
-
+export default function List({ listItems, error, loading, token }) {
   const markItemPurchased = (e, id) => {
     const elapsedMilliseconds = Date.now();
 
     if (e.target.checked === true) {
-      db.collection(props.token).doc(id).update({
+      db.collection(token).doc(id).update({
         last_purchased: elapsedMilliseconds,
       });
     }
@@ -24,14 +19,14 @@ export default function List(props) {
 
   return (
     <>
-      <h1>Your token: {props.token}</h1>
+      <h1>Your token: {token}</h1>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Collection: Loading...</span>}
-      {listItem && (
+      {listItems && (
         <>
           <span>Your Shopping List:</span>
           <ul>
-            {listItem.docs.map((doc) => (
+            {listItems.docs.map((doc) => (
               <li key={doc.id} className="checkbox-wrapper">
                 <label>
                   <input

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -1,6 +1,11 @@
 import { db } from '../lib/firebase';
+import { useCollection } from 'react-firebase-hooks/firestore';
 
-export default function List({ listItems, error, loading, token }) {
+export default function List({ token }) {
+  const [listItems, loading, error] = useCollection(db.collection(token), {
+    snapshotListenOptions: { includeMetadataChanges: true },
+  });
+
   const markItemPurchased = (e, id) => {
     const elapsedMilliseconds = Date.now();
 


### PR DESCRIPTION
## Description

**IMPORTANT! Only merge this PR once issue 8 (#9) has been merged! I created this branch off that branch. Next time I'll know to create a branch off `main`.**

This PR completely removes the REST-style GET request to the Firebase API, and instead takes advantage of the Firebase hook, `useCollection`, in both `List.js` and `AddItem.js`. After discussing the issue with @skylerwshaw, I have a much better understanding how Firebase useCollection hook works, providing a constant down-stream of data. When we had the fetch inside our `useEffect()`, we were not leveraging the power of Firebase via the useCollection hook.

## Related Issue

closes #23 

## Acceptance Criteria

This PR goes a different direction than the original issue. Having the connection to Firebase in `App.js` makes a lot of sense. But it causes more headaches/bugs than it solves, because before the `token` is fully resolved in its `useEffect()` the useCollection hook runs with an empty `token`. 

So we definitely want to leverage `useCollection` but we need to have a persisted `token` first. And because the way we route between either `List.js` OR `AddItem.js`, the connection to the database via `useCollection` will never be called simultaneously between the two components. 

@skylerwshaw helped me liken it to how Redux provides a central store of state for the whole app to access. Firestore is kind of like our central store, and we're reading from it similarly how you might request data from Redux central store in multiple components. 

After all those considerations, I don't see it as a negative having `useCollection` called in two different components.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  | :sparkles: New feature     |
|  ✓   | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

- Remove the `useEffect()` containg our `.get()` request to Firestore.
- Add useCollection to both `List.js` and `AddItem.js`.

### Before

In `App.js`:

```javascript
 useEffect(() => {
    if (token) {
      db.collection(token)
        .get()
        .then((querySnapshot) => {
          const listItemData = [];

          querySnapshot.forEach((doc) => {
            listItemData.push(doc.data());
          });
          setListItems(listItemData);
        });
    }
  }, [token]);
```


### After

Added to `List.js` and `AddItem.js`:

```javascript
 const [listItems, loading, error] = useCollection(db.collection(token), {
    snapshotListenOptions: { includeMetadataChanges: true },
 });
```

## Testing Steps / QA Criteria

1. CD into `tcl-23-smart-shopping-list`
2. Run `git checkout main`
3. Run `git pull`
4. Run `git checkout jc-use-collection-instead-of-get`
5. Run `npm install`
6. Run `npm start`
7. Notice that everything still works great!

