### PR TITLE
Filter To Locate Item On Existing List

### DIFF
--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -8,10 +8,10 @@ export default function List({ token }) {
   const [listItem, loading, error] = useCollection(db.collection(token), {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
-  const [filter, setFilter] = useState('');
+  const [query, setQuery] = useState('');
 
   function handleReset() {
-    setFilter('');
+    setQuery('');
   }
   const markItemPurchased = (e, id) => {
     const elapsedMilliseconds = Date.now();
@@ -33,13 +33,14 @@ export default function List({ token }) {
     <>
       <h1>This Is Your Grocery List</h1>
       <h2>It uses the token: {token}</h2>
-      <label for="thesearch">
+      <label htmlFor="thesearch">
         Search Grocery List Items
         <input
           type="text"
           placeholder="enter grocery item"
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
+          value={query}
+          id="thesearch"
+          onChange={(e) => setQuery(e.target.value)}
         />
         <button onClick={handleReset}>Reset Text Field</button>
       </label>
@@ -60,16 +61,15 @@ export default function List({ token }) {
               {listItem.docs
                 .filter(
                   (doc) =>
-                    doc
-                      .data()
-                      .item_name.includes(filter.toLowerCase().trim()) ||
-                    filter === '',
+                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
+                    query === '',
                 )
                 .map((doc, index) => (
                   <li key={doc.id} className="checkbox-wrapper">
-                    <label for={`grocery-item${++index}`}>
+                    <label htmlFor={`grocery-item${++index}`}>
                       <input
                         type="checkbox"
+                        id={`grocery-item${++index}`}
                         defaultChecked={compareTimeStamps(
                           doc.data().last_purchased,
                         )}

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -60,7 +60,10 @@ export default function List({ token }) {
               {listItem.docs
                 .filter(
                   (doc) =>
-                    doc.data().item_name.includes(filter) || filter === '',
+                    doc
+                      .data()
+                      .item_name.includes(filter.toLowerCase().trim()) ||
+                    filter === '',
                 )
                 .map((doc, index) => (
                   <li key={doc.id} className="checkbox-wrapper">

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -33,9 +33,11 @@ export default function List({ token }) {
     <>
       <h1>This Is Your Grocery List</h1>
       <h2>It uses the token: {token}</h2>
-      <label>
+      <label for="thesearch">
+        Search Grocery List Items
         <input
           type="text"
+          placeholder="enter grocery item"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
         />
@@ -60,9 +62,9 @@ export default function List({ token }) {
                   (doc) =>
                     doc.data().item_name.includes(filter) || filter === '',
                 )
-                .map((doc) => (
+                .map((doc, index) => (
                   <li key={doc.id} className="checkbox-wrapper">
-                    <label>
+                    <label for={`grocery-item${++index}`}>
                       <input
                         type="checkbox"
                         defaultChecked={compareTimeStamps(

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { db } from '../lib/firebase';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import { useHistory } from 'react-router-dom';
@@ -7,12 +8,12 @@ export default function List({ token }) {
   const [listItem, loading, error] = useCollection(db.collection(token), {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
+  const [filter, setFilter] = useState('');
 
   function handleReset() {
     // we will reset state
     console.log(handleReset, 'button clicks');
   }
-
   const markItemPurchased = (e, id) => {
     const elapsedMilliseconds = Date.now();
 
@@ -34,7 +35,11 @@ export default function List({ token }) {
       <h1>This Is Your Grocery List</h1>
       <h2>It uses the token: {token}</h2>
       <label>
-        <input type="text"></input>
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
         <button onClick={handleReset}>Reset Text Field</button>
       </label>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -11,8 +11,7 @@ export default function List({ token }) {
   const [filter, setFilter] = useState('');
 
   function handleReset() {
-    // we will reset state
-    console.log(handleReset, 'button clicks');
+    setFilter('');
   }
   const markItemPurchased = (e, id) => {
     const elapsedMilliseconds = Date.now();
@@ -56,21 +55,26 @@ export default function List({ token }) {
             </section>
           ) : (
             <ul>
-              {listItem.docs.map((doc) => (
-                <li key={doc.id} className="checkbox-wrapper">
-                  <label>
-                    <input
-                      type="checkbox"
-                      defaultChecked={compareTimeStamps(
-                        doc.data().last_purchased,
-                      )}
-                      disabled={compareTimeStamps(doc.data().last_purchased)}
-                      onClick={(e) => markItemPurchased(e, doc.id)}
-                    />
-                    {doc.data().item_name}
-                  </label>
-                </li>
-              ))}
+              {listItem.docs
+                .filter(
+                  (doc) =>
+                    doc.data().item_name.includes(filter) || filter === '',
+                )
+                .map((doc) => (
+                  <li key={doc.id} className="checkbox-wrapper">
+                    <label>
+                      <input
+                        type="checkbox"
+                        defaultChecked={compareTimeStamps(
+                          doc.data().last_purchased,
+                        )}
+                        disabled={compareTimeStamps(doc.data().last_purchased)}
+                        onClick={(e) => markItemPurchased(e, doc.id)}
+                      />
+                      {doc.data().item_name}
+                    </label>
+                  </li>
+                ))}
             </ul>
           )}
         </>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -8,6 +8,11 @@ export default function List({ token }) {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
 
+  function handleReset() {
+    // we will reset state
+    console.log(handleReset, 'button clicks');
+  }
+
   const markItemPurchased = (e, id) => {
     const elapsedMilliseconds = Date.now();
 
@@ -28,11 +33,15 @@ export default function List({ token }) {
     <>
       <h1>This Is Your Grocery List</h1>
       <h2>It uses the token: {token}</h2>
+      <label>
+        <input type="text"></input>
+        <button onClick={handleReset}>Reset Text Field</button>
+      </label>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Grocery List: Loading...</span>}
       {listItem && (
         <>
-          <span>Grocery List:</span>
+          <h2>Grocery List:</h2>
           {listItem.docs.length === 0 ? (
             <section>
               <p>Your grocery list is currently empty.</p>


### PR DESCRIPTION
## Description

This week, the main point of the story is the following: As a user, I want to filter my shopping list to make it easier to locate an item in the list. 

All code changes are contained within the `/List.js` component. We were able to build off of last week's `.map` by utilizing the `filter()` method. We also utilized `setState`. Since we are simply needing to make a request, rather than needing to apply any changes to the Firestore database during this list filtration, utilizing `setState` seemed like a good option to use.

In addition, we addressed accessibility for the additions for this AC.



## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes https://github.com/the-collab-lab/tcl-23-smart-shopping-list/issues/10



## Acceptance Criteria

- [x] Display a text field above the top of the shopping list

- [x] As the user types into the field, the list should narrow to display only items that contain the text the user entered in the filter field

- [x] When the field has text in it, the user should be able to tap a UI element (e.g., with an "X" button next to the field) to clear the field

- [x] The filter text should match any part of the item name (i.e. it should not only match from the start of the string)



## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |



## Updates


### Before

If a user wants to determine if an item exists in the grocery list, their option is to visually scan the list. 

<img width="415" alt="filterBefore" src="https://user-images.githubusercontent.com/38255956/116943253-cd73da80-ac38-11eb-84f9-5120180717e5.png">


### After

User is provided a labeled input where they can type to search their existing grocery list for items that may or may not be in it. A `Reset Text Field` button exists to clear the input field.

https://user-images.githubusercontent.com/38255956/117242015-00b19780-adfa-11eb-8137-534d6c4aa853.mov



## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

1. Navigate to branch `ar-jw-filter-list`
2. `npm install` (for luck!)
3. `npm start`
4. Once you are on `localhost:3000`, navigate to `localhost:3000/list`
5. If you would like to use a currently existing token with a list, you can use `apart havoc vega`. You are welcome to create your own token and list for testing if you would prefer.
6. If you chose to create your own token and list, make sure you have added a few items to your list. Including items that share varying quantities of characters in the same order will demonstrate the new functionality. Example: `drinking straws`, `strawberries`, `blueberries`
7. In the text field, start typing something that is in your list. You should see the list items change to match what you have typed. 
8. When done typing, click `Reset Text Field` to clear the text input field.

