### PR TITLE
List Items By Frequency Purchased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9813,6 +9813,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.27.0.tgz",
+      "integrity": "sha512-VKsFsPggTA0DvnxtJdiExAucKdAnwbCCNlMM5ENvHlxubqWd0xhZcdb4XgZ7QFNhaRhilXCFxHuoObP5BNA4PA=="
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "firebase": "^8.3.2",
+    "luxon": "^1.27.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebase-hooks": "^3.0.3",

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -100,8 +100,10 @@ export default function List({ token }) {
               {alphabetizeListItems(listItems.docs)
                 .filter(
                   (doc) =>
-                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
-                    query === '',
+                    doc
+                      .data()
+                      .item_name.toLowerCase()
+                      .includes(query.toLowerCase().trim()) || query === '',
                 )
                 .filter((item) => {
                   if (item.data().times_purchased === 0) {
@@ -137,8 +139,10 @@ export default function List({ token }) {
               {alphabetizeListItems(listItems.docs)
                 .filter(
                   (doc) =>
-                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
-                    query === '',
+                    doc
+                      .data()
+                      .item_name.toLowerCase()
+                      .includes(query.toLowerCase().trim()) || query === '',
                 )
                 .filter((item) => {
                   if (item.data().times_purchased === 0) {
@@ -177,8 +181,10 @@ export default function List({ token }) {
               {alphabetizeListItems(listItems.docs)
                 .filter(
                   (doc) =>
-                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
-                    query === '',
+                    doc
+                      .data()
+                      .item_name.toLowerCase()
+                      .includes(query.toLowerCase().trim()) || query === '',
                 )
                 .filter((item) => {
                   if (item.data().times_purchased === 0) {
@@ -217,8 +223,10 @@ export default function List({ token }) {
               {alphabetizeListItems(listItems.docs)
                 .filter(
                   (doc) =>
-                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
-                    query === '',
+                    doc
+                      .data()
+                      .item_name.toLowerCase()
+                      .includes(query.toLowerCase().trim()) || query === '',
                 )
                 .filter(
                   (item) =>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -207,6 +207,14 @@ export default function List({ token }) {
     });
   };
 
+  const filterByInactiveItems = (listItems) => {
+    // filter the items by user input
+    const alphabetizedItems = filterByUserInput(listItems);
+
+    // filter items into the gray category of more than double last_estimate
+    return alphabetizedItems.filter((item) => checkForInactiveItem(item));
+  };
+
   return (
     <>
       <h1>This Is Your Grocery List</h1>
@@ -303,38 +311,27 @@ export default function List({ token }) {
                 </li>
               ))}
 
-              {alphabetizeListItems(listItems.docs)
-                .filter(
-                  (doc) =>
-                    doc
-                      .data()
-                      .item_name.toLowerCase()
-                      .includes(query.toLowerCase().trim()) || query === '',
-                )
-                // filter items that return true from checkForInactiveItem()
-                .filter((item) => checkForInactiveItem(item))
-
-                .map((doc) => (
-                  <li
-                    key={doc.id}
-                    className="checkbox-wrapper"
-                    style={{ color: 'gray' }}
-                  >
-                    <input
-                      type="checkbox"
-                      id={doc.id}
-                      defaultChecked={compareTimeStamps(
-                        doc.data().last_purchased,
-                      )}
-                      disabled={compareTimeStamps(doc.data().last_purchased)}
-                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                    />
-                    <label htmlFor={doc.id}>{doc.data().item_name}</label>
-                    <button key={doc.id} onClick={() => deleteItem(doc.id)}>
-                      Delete
-                    </button>
-                  </li>
-                ))}
+              {filterByInactiveItems(listItems).map((doc) => (
+                <li
+                  key={doc.id}
+                  className="checkbox-wrapper"
+                  style={{ color: 'gray' }}
+                >
+                  <input
+                    type="checkbox"
+                    id={doc.id}
+                    defaultChecked={compareTimeStamps(
+                      doc.data().last_purchased,
+                    )}
+                    disabled={compareTimeStamps(doc.data().last_purchased)}
+                    onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                  />
+                  <label htmlFor={doc.id}>{doc.data().item_name}</label>
+                  <button key={doc.id} onClick={() => deleteItem(doc.id)}>
+                    Delete
+                  </button>
+                </li>
+              ))}
             </ul>
           )}
         </>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -6,7 +6,7 @@ import calculateEstimate from '../lib/estimates';
 
 export default function List({ token }) {
   const history = useHistory();
-  const [listItem, loading, error] = useCollection(db.collection(token), {
+  const [listItems, loading, error] = useCollection(db.collection(token), {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
   const [query, setQuery] = useState('');
@@ -72,10 +72,10 @@ export default function List({ token }) {
       </label>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Grocery List: Loading...</span>}
-      {listItem && (
+      {listItems && (
         <>
           <h2>Grocery List:</h2>
-          {listItem.docs.length === 0 ? (
+          {listItems.docs.length === 0 ? (
             <section>
               <p>Your grocery list is currently empty.</p>
               <button onClick={() => history.push('/add-item')}>
@@ -84,7 +84,7 @@ export default function List({ token }) {
             </section>
           ) : (
             <ul>
-              {listItem.docs
+              {listItems.docs
                 .filter(
                   (doc) =>
                     doc.data().item_name.includes(query.toLowerCase().trim()) ||

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -126,20 +126,18 @@ export default function List({ token }) {
                     className="checkbox-wrapper"
                     style={{ color: 'green', fontSize: '1.25rem' }}
                   >
-                    <label htmlFor={`grocery-item${++index}`}>
-                      <input
-                        type="checkbox"
-                        id={`grocery-item${++index}`}
-                        defaultChecked={compareTimeStamps(
-                          doc.data().last_purchased,
-                        )}
-                        disabled={compareTimeStamps(doc.data().last_purchased)}
-                        onClick={(e) =>
-                          markItemPurchased(e, doc.id, doc.data())
-                        }
-                      />
-                      {doc.data().item_name}
-                    </label>
+                    <input
+                      type="checkbox"
+                      aria-label={`grocery-item${++index}`}
+                      aria-required="true"
+                      id={`grocery-item${++index}`}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
+                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                    />
+                    {doc.data().item_name}
                   </li>
                 ))}
 
@@ -169,20 +167,18 @@ export default function List({ token }) {
                     className="checkbox-wrapper"
                     style={{ color: 'purple', fontSize: '1.25rem' }}
                   >
-                    <label htmlFor={`grocery-item${++index}`}>
-                      <input
-                        type="checkbox"
-                        id={`grocery-item${++index}`}
-                        defaultChecked={compareTimeStamps(
-                          doc.data().last_purchased,
-                        )}
-                        disabled={compareTimeStamps(doc.data().last_purchased)}
-                        onClick={(e) =>
-                          markItemPurchased(e, doc.id, doc.data())
-                        }
-                      />
-                      {doc.data().item_name}
-                    </label>
+                    <input
+                      type="checkbox"
+                      aria-label={`grocery-item${++index}`}
+                      aria-required="true"
+                      id={`grocery-item${++index}`}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
+                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                    />
+                    {doc.data().item_name}
                   </li>
                 ))}
 
@@ -211,20 +207,18 @@ export default function List({ token }) {
                     className="checkbox-wrapper"
                     style={{ color: 'red', fontSize: '1.25rem' }}
                   >
-                    <label htmlFor={`grocery-item${++index}`}>
-                      <input
-                        type="checkbox"
-                        id={`grocery-item${++index}`}
-                        defaultChecked={compareTimeStamps(
-                          doc.data().last_purchased,
-                        )}
-                        disabled={compareTimeStamps(doc.data().last_purchased)}
-                        onClick={(e) =>
-                          markItemPurchased(e, doc.id, doc.data())
-                        }
-                      />
-                      {doc.data().item_name}
-                    </label>
+                    <input
+                      type="checkbox"
+                      aria-label={`grocery-item${++index}`}
+                      aria-required="true"
+                      id={`grocery-item${++index}`}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
+                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                    />
+                    {doc.data().item_name}
                   </li>
                 ))}
 

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -79,13 +79,9 @@ export default function List({ token }) {
     const nowInDays = Math.floor(now.ts / millisecondsInADay);
 
     // do the same conversion for last_purchased as lastPurchased
-    // this parse isn't accepting the format from database. Need to parse differently
-    // it appears to be parsing the time now as it happens, but I just want the conversion back to milliseconds
     const lastPurchasedToDays = Math.floor(
       DateTime.fromISO(lastPurchased).ts / millisecondsInADay,
     );
-
-    console.log(nowInDays, lastPurchasedToDays);
 
     return nowInDays - lastPurchasedToDays === 0;
   }
@@ -103,9 +99,14 @@ export default function List({ token }) {
     return sortedList;
   };
 
-  const checkForInactiveItem = (item) =>
-    Math.floor(Date.now() / 86400000) - item.data().last_purchased <
-    item.data().last_estimate;
+  const checkForInactiveItem = (item) => {
+    console.log(item);
+    if (item.times_purchased === 1) {
+      return true;
+    }
+
+    return false;
+  };
 
   return (
     <>
@@ -265,14 +266,7 @@ export default function List({ token }) {
                       .item_name.toLowerCase()
                       .includes(query.toLowerCase().trim()) || query === '',
                 )
-                .filter(
-                  (item) =>
-                    (Math.floor(Date.now() / 86400000) -
-                      item.data().last_purchased) *
-                      2 >
-                      item.data().last_estimate &&
-                    item.data().last_estimate !== null,
-                )
+                .filter((item) => checkForInactiveItem(item.data()))
 
                 .map((doc, index) => (
                   <li

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -10,28 +10,23 @@ export default function List({ token }) {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
   const [query, setQuery] = useState('');
-  const [alphabetizedListItems, setAlphabetizedListItems] = useState([]);
 
   function handleReset() {
     setQuery('');
   }
 
-  useEffect(() => {
-    if (listItems) {
-      const abcListItems = listItems.docs.sort((a, b) => {
-        if (a.data().item_name < b.data().item_name) {
-          return -1;
-        }
-        if (a.data().item_name > b.data().item_name) {
-          return 1;
-        }
-        return 0;
-      });
-      setAlphabetizedListItems(abcListItems);
-    }
-  }, [setAlphabetizedListItems, listItems]);
-
-  // console.log(listItems.docs.map((doc) => doc.data().item_name));
+  const alphabetizeListItems = (list) => {
+    const sortedList = list.sort((a, b) => {
+      if (a.data().item_name < b.data().item_name) {
+        return -1;
+      }
+      if (a.data().item_name > b.data().item_name) {
+        return 1;
+      }
+      return 0;
+    });
+    return sortedList;
+  };
 
   const markItemPurchased = (e, id, itemData) => {
     const currentTimestamp = Math.round(Date.now() / 86400000);
@@ -102,7 +97,7 @@ export default function List({ token }) {
             </section>
           ) : (
             <ul>
-              {listItems.docs
+              {alphabetizeListItems(listItems.docs)
                 .filter(
                   (doc) =>
                     doc.data().item_name.includes(query.toLowerCase().trim()) ||

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -184,7 +184,7 @@ export default function List({ token }) {
                   >
                     <input
                       type="checkbox"
-                      aria-label={`grocery-item${++index}`}
+                      aria-label={doc.data().item_name}
                       aria-required="true"
                       id={`grocery-item${++index}`}
                       defaultChecked={compareTimeStamps(
@@ -225,7 +225,7 @@ export default function List({ token }) {
                   >
                     <input
                       type="checkbox"
-                      aria-label={`grocery-item${++index}`}
+                      aria-label={doc.data().item_name}
                       aria-required="true"
                       id={`grocery-item${++index}`}
                       defaultChecked={compareTimeStamps(
@@ -265,7 +265,7 @@ export default function List({ token }) {
                   >
                     <input
                       type="checkbox"
-                      aria-label={`grocery-item${++index}`}
+                      aria-label={doc.data().item_name}
                       aria-required="true"
                       id={`grocery-item${++index}`}
                       defaultChecked={compareTimeStamps(
@@ -297,6 +297,7 @@ export default function List({ token }) {
                     <label htmlFor={`grocery-item${++index}`}>
                       <input
                         type="checkbox"
+                        aria-label={doc.data().item_name}
                         id={`grocery-item${++index}`}
                         defaultChecked={compareTimeStamps(
                           doc.data().last_purchased,

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -34,7 +34,7 @@ export default function List({ token }) {
       DateTime.fromISO(itemData.last_purchased).ts / millisecondsInADay,
     );
 
-    // determine the amount of days between last marked purchased
+    // determine the amount of days between now and when item was last marked purchased
     const latestInterval = nowInDays - lastPurchasedToDays;
 
     if (e.target.checked === true) {
@@ -66,10 +66,26 @@ export default function List({ token }) {
   };
 
   function compareTimeStamps(lastPurchased) {
-    // currentTimeInMilliseconds is used to compare the last_purchased property and make sure that it is less a day in milliseconds
-    const currentTimeInMilliseconds = Date.now();
-    const oneDayInMilliseconds = 86400000;
-    return currentTimeInMilliseconds - lastPurchased < oneDayInMilliseconds;
+    // first check to see if lastPurchased === null in database
+    if (lastPurchased === null) {
+      return false;
+    } else {
+      // use DateTime package to get current time
+      const now = DateTime.now();
+
+      // initialize how many milliseconds there are in a day for calculation
+      const millisecondsInADay = 86400000;
+
+      // convert now to days
+      const nowInDays = Math.floor(now.ts / millisecondsInADay);
+
+      // do the same conversion for last_purchased as lastPurchased
+      const lastPurchasedToDays = Math.floor(
+        DateTime.fromISO(lastPurchased).ts / millisecondsInADay,
+      );
+
+      return nowInDays - lastPurchasedToDays === 0;
+    }
   }
 
   const alphabetizeListItems = (list) => {
@@ -148,10 +164,10 @@ export default function List({ token }) {
                       aria-label={`grocery-item${++index}`}
                       aria-required="true"
                       id={`grocery-item${++index}`}
-                      // defaultChecked={compareTimeStamps(
-                      //   doc.data().last_purchased,
-                      // )}
-                      // disabled={compareTimeStamps(doc.data().last_purchased)}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
                       onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
                     />
                     {doc.data().item_name}

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -209,8 +209,8 @@ export default function List({ token }) {
                     return item.data().purchase_frequency === 14;
                   } else {
                     return (
-                      (item.data().last_estimate >= 7 ||
-                        item.data().last_estimate <= 30) &&
+                      item.data().last_estimate >= 7 &&
+                      item.data().last_estimate <= 30 &&
                       !checkForInactiveItem(item.data())
                     );
                   }

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -16,18 +16,14 @@ export default function List({ token }) {
   }
 
   const markItemPurchased = (e, id, itemData) => {
-    const currentTimestamp = Date.now();
-    const initialInterval = itemData.purchase_frequency * 86400000;
+    const currentTimestamp = Math.round(Date.now() / 86400000);
     const latestInterval = currentTimestamp - itemData.last_purchased;
-
-    // const markItemPurchased = (e, id) => {
-    //   const elapsedMilliseconds = Date.now();
 
     if (e.target.checked === true) {
       if (itemData.times_purchased === 0) {
         const initialEstimate = calculateEstimate(
           itemData.last_estimate,
-          initialInterval,
+          itemData.purchase_frequency,
           itemData.times_purchased,
         );
         db.collection(token)
@@ -55,9 +51,8 @@ export default function List({ token }) {
   };
 
   function compareTimeStamps(lastPurchased) {
-    const currentElapsedMilliseconds = Date.now();
-    const millisecondsInOneDay = 86400000;
-    return currentElapsedMilliseconds - lastPurchased < millisecondsInOneDay;
+    const currentTimestamp = Math.round(Date.now() / 86400000);
+    return currentTimestamp - lastPurchased < lastPurchased;
   }
 
   return (

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -179,7 +179,7 @@ export default function List({ token }) {
     // filter the items by user input
     const alphabetizedItems = filterByUserInput(listItems);
 
-    // filter items that have have a last_estimate between 7 or more and 30 or less days
+    // filter items into the purple category of more than 7 days and less than 30 days
     return alphabetizedItems.filter((item) => {
       if (item.data().times_purchased === 0) {
         return item.data().purchase_frequency === 14;
@@ -189,6 +189,20 @@ export default function List({ token }) {
           item.data().last_estimate <= 30 &&
           !checkForInactiveItem(item)
         );
+      }
+    });
+  };
+
+  const filterByMoreThanThirtyDays = (listItems) => {
+    // filter the items by user input
+    const alphabetizedItems = filterByUserInput(listItems);
+
+    // filter items into the red category of more than 30 days
+    return alphabetizedItems.filter((item) => {
+      if (item.data().times_purchased === 0) {
+        return item.data().purchase_frequency === 30;
+      } else {
+        return item.data().last_estimate > 30 && !checkForInactiveItem(item);
       }
     });
   };
@@ -267,47 +281,27 @@ export default function List({ token }) {
                 ),
               )}
 
-              {alphabetizeListItems(listItems.docs)
-                .filter(
-                  (doc) =>
-                    doc
-                      .data()
-                      .item_name.toLowerCase()
-                      .includes(query.toLowerCase().trim()) || query === '',
-                )
-                // filter items that have a last_estimate of more than 30 days
-                .filter((item) => {
-                  if (item.data().times_purchased === 0) {
-                    return item.data().purchase_frequency === 30;
-                  } else {
-                    return (
-                      item.data().last_estimate > 30 &&
-                      !checkForInactiveItem(item)
-                    );
-                  }
-                })
-
-                .map((doc) => (
-                  <li
-                    key={doc.id}
-                    className="checkbox-wrapper"
-                    style={{ color: 'red' }}
-                  >
-                    <input
-                      type="checkbox"
-                      id={doc.id}
-                      defaultChecked={compareTimeStamps(
-                        doc.data().last_purchased,
-                      )}
-                      disabled={compareTimeStamps(doc.data().last_purchased)}
-                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                    />
-                    <label htmlFor={doc.id}>{doc.data().item_name}</label>
-                    <button key={doc.id} onClick={() => deleteItem(doc.id)}>
-                      Delete
-                    </button>
-                  </li>
-                ))}
+              {filterByMoreThanThirtyDays(listItems).map((doc) => (
+                <li
+                  key={doc.id}
+                  className="checkbox-wrapper"
+                  style={{ color: 'red' }}
+                >
+                  <input
+                    type="checkbox"
+                    id={doc.id}
+                    defaultChecked={compareTimeStamps(
+                      doc.data().last_purchased,
+                    )}
+                    disabled={compareTimeStamps(doc.data().last_purchased)}
+                    onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                  />
+                  <label htmlFor={doc.id}>{doc.data().item_name}</label>
+                  <button key={doc.id} onClick={() => deleteItem(doc.id)}>
+                    Delete
+                  </button>
+                </li>
+              ))}
 
               {alphabetizeListItems(listItems.docs)
                 .filter(

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -102,7 +102,9 @@ export default function List({ token }) {
 
   const checkForInactiveItem = (item) => {
     // pass in the item and create a variable for item.data() here
-    if (item.times_purchased === 1) {
+    const itemData = item.data();
+
+    if (itemData.times_purchased === 1) {
       return true;
     }
 
@@ -117,9 +119,9 @@ export default function List({ token }) {
 
     // do the same conversion for last_purchased as lastPurchased
     const lastPurchasedToDays = Math.floor(
-      DateTime.fromISO(item.last_purchased).ts / millisecondsInADay,
+      DateTime.fromISO(itemData.last_purchased).ts / millisecondsInADay,
     );
-    const doubleLastEstimate = item.last_estimate * 2;
+    const doubleLastEstimate = itemData.last_estimate * 2;
     const timeEllapsed = nowInDays - lastPurchasedToDays;
 
     if (timeEllapsed > doubleLastEstimate) {
@@ -171,7 +173,7 @@ export default function List({ token }) {
                   } else {
                     return (
                       item.data().last_estimate < 7 &&
-                      !checkForInactiveItem(item.data())
+                      !checkForInactiveItem(item)
                     );
                   }
                 })
@@ -216,7 +218,7 @@ export default function List({ token }) {
                     return (
                       item.data().last_estimate >= 7 &&
                       item.data().last_estimate <= 30 &&
-                      !checkForInactiveItem(item.data())
+                      !checkForInactiveItem(item)
                     );
                   }
                 })
@@ -260,7 +262,7 @@ export default function List({ token }) {
                   } else {
                     return (
                       item.data().last_estimate > 30 &&
-                      !checkForInactiveItem(item.data())
+                      !checkForInactiveItem(item)
                     );
                   }
                 })
@@ -298,7 +300,7 @@ export default function List({ token }) {
                       .item_name.toLowerCase()
                       .includes(query.toLowerCase().trim()) || query === '',
                 )
-                .filter((item) => checkForInactiveItem(item.data()))
+                .filter((item) => checkForInactiveItem(item))
 
                 .map((doc, index) => (
                   <li

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -38,7 +38,7 @@ export default function List({ token }) {
     const latestInterval = nowInDays - lastPurchasedToDays;
 
     if (e.target.checked === true) {
-      // if an item does has not yet been purchased, there isn't a last_estimate value, so we initialize with the user's selected purchase_frequency
+      // if an item has not yet been purchased, last_estimate has no value, so we initialize with the user's selected purchase_frequency
       if (itemData.times_purchased === 0) {
         db.collection(token)
           .doc(id)

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -175,6 +175,24 @@ export default function List({ token }) {
     });
   };
 
+  const filterByMoreThanSevenDaysAndLessThanThirtyDays = (listItems) => {
+    // filter the items by user input
+    const alphabetizedItems = filterByUserInput(listItems);
+
+    // filter items that have have a last_estimate between 7 or more and 30 or less days
+    return alphabetizedItems.filter((item) => {
+      if (item.data().times_purchased === 0) {
+        return item.data().purchase_frequency === 14;
+      } else {
+        return (
+          item.data().last_estimate >= 7 &&
+          item.data().last_estimate <= 30 &&
+          !checkForInactiveItem(item)
+        );
+      }
+    });
+  };
+
   return (
     <>
       <h1>This Is Your Grocery List</h1>
@@ -225,28 +243,8 @@ export default function List({ token }) {
                 </li>
               ))}
 
-              {alphabetizeListItems(listItems.docs)
-                .filter(
-                  (doc) =>
-                    doc
-                      .data()
-                      .item_name.toLowerCase()
-                      .includes(query.toLowerCase().trim()) || query === '',
-                )
-                // filter items that have have a last_estimate between 7 or more and 30 or less days
-                .filter((item) => {
-                  if (item.data().times_purchased === 0) {
-                    return item.data().purchase_frequency === 14;
-                  } else {
-                    return (
-                      item.data().last_estimate >= 7 &&
-                      item.data().last_estimate <= 30 &&
-                      !checkForInactiveItem(item)
-                    );
-                  }
-                })
-
-                .map((doc) => (
+              {filterByMoreThanSevenDaysAndLessThanThirtyDays(listItems).map(
+                (doc) => (
                   <li
                     key={doc.id}
                     className="checkbox-wrapper"
@@ -266,7 +264,8 @@ export default function List({ token }) {
                       Delete
                     </button>
                   </li>
-                ))}
+                ),
+              )}
 
               {alphabetizeListItems(listItems.docs)
                 .filter(

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -16,8 +16,9 @@ export default function List({ token }) {
   }
 
   const markItemPurchased = (e, id, itemData) => {
-    const currentTimestamp = Math.floor(Date.now() / 86400000);
-    const latestInterval = currentTimestamp - itemData.last_purchased;
+    // currentTimeInDays takes the number of milliseconds since January 1, 1970 and converts to days
+    const currentTimeInDays = Math.floor(Date.now() / 86400000);
+    const latestInterval = currentTimeInDays - itemData.last_purchased;
 
     if (e.target.checked === true) {
       if (itemData.times_purchased === 0) {
@@ -29,7 +30,7 @@ export default function List({ token }) {
         db.collection(token)
           .doc(id)
           .update({
-            last_purchased: currentTimestamp,
+            last_purchased: currentTimeInDays,
             times_purchased: itemData.times_purchased + 1,
             last_estimate: initialEstimate,
           });
@@ -42,7 +43,7 @@ export default function List({ token }) {
         db.collection(token)
           .doc(id)
           .update({
-            last_purchased: currentTimestamp,
+            last_purchased: currentTimeInDays,
             times_purchased: itemData.times_purchased + 1,
             last_estimate: latestEstimate,
           });
@@ -51,8 +52,8 @@ export default function List({ token }) {
   };
 
   function compareTimeStamps(lastPurchased) {
-    const currentTimestamp = Math.floor(Date.now() / 86400000);
-    return currentTimestamp - lastPurchased < 1;
+    const currentTimeInDays = Math.floor(Date.now() / 86400000);
+    return currentTimeInDays - lastPurchased < 1;
   }
 
   const alphabetizeListItems = (list) => {

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -103,7 +103,13 @@ export default function List({ token }) {
                     doc.data().item_name.includes(query.toLowerCase().trim()) ||
                     query === '',
                 )
-                .filter((item) => item.data().last_estimate <= 7)
+                .filter((item) => {
+                  if (item.data().times_purchased === 0) {
+                    return item.data().purchase_frequency === 7;
+                  } else {
+                    return item.data().last_estimate <= 7;
+                  }
+                })
 
                 .map((doc, index) => (
                   <li
@@ -134,11 +140,16 @@ export default function List({ token }) {
                     doc.data().item_name.includes(query.toLowerCase().trim()) ||
                     query === '',
                 )
-                .filter(
-                  (item) =>
-                    item.data().last_estimate > 7 &&
-                    item.data().last_estimate <= 30,
-                )
+                .filter((item) => {
+                  if (item.data().times_purchased === 0) {
+                    return item.data().purchase_frequency === 14;
+                  } else {
+                    return (
+                      item.data().last_estimate > 7 &&
+                      item.data().last_estimate <= 14
+                    );
+                  }
+                })
 
                 .map((doc, index) => (
                   <li
@@ -169,11 +180,16 @@ export default function List({ token }) {
                     doc.data().item_name.includes(query.toLowerCase().trim()) ||
                     query === '',
                 )
-                .filter(
-                  (item) =>
-                    item.data().last_estimate > 30 &&
-                    item.data().last_estimate < item.data().last_estimate * 2,
-                )
+                .filter((item) => {
+                  if (item.data().times_purchased === 0) {
+                    return item.data().purchase_frequency === 30;
+                  } else {
+                    return (
+                      item.data().last_estimate > 14 &&
+                      item.data().last_estimate <= 30
+                    );
+                  }
+                })
 
                 .map((doc, index) => (
                   <li
@@ -206,7 +222,11 @@ export default function List({ token }) {
                 )
                 .filter(
                   (item) =>
-                    item.data().last_estimate >= item.data().last_estimate * 2,
+                    (Math.floor(Date.now() / 86400000) -
+                      item.data().last_purchased) *
+                      2 >
+                      item.data().last_estimate &&
+                    item.data().last_estimate !== null,
                 )
 
                 .map((doc, index) => (

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -16,11 +16,12 @@ export default function List({ token }) {
   }
 
   const markItemPurchased = (e, id, itemData) => {
-    // currentTimeInDays takes the number of milliseconds since January 1, 1970 and converts to days
-    const currentTimeInDays = Math.floor(Date.now() / 86400000);
-    const latestInterval = currentTimeInDays - itemData.last_purchased;
+    // currentTimeInMilliseconds is used to update the last_purchased property for greater accurary
+    const currentTimeInMilliseconds = Date.now();
+    const latestInterval = currentTimeInMilliseconds - itemData.last_purchased;
 
     if (e.target.checked === true) {
+      // if an item does has not yet been purchased, there isn't a last_estimate value, so we initialize with the user's selected purchase_frequency
       if (itemData.times_purchased === 0) {
         const initialEstimate = calculateEstimate(
           itemData.last_estimate,
@@ -30,10 +31,11 @@ export default function List({ token }) {
         db.collection(token)
           .doc(id)
           .update({
-            last_purchased: currentTimeInDays,
+            last_purchased: currentTimeInMilliseconds,
             times_purchased: itemData.times_purchased + 1,
             last_estimate: initialEstimate,
           });
+        // if an item has at least 1 times_purchased, we use the last_estimate property to update the database last_estimate property
       } else {
         const latestEstimate = calculateEstimate(
           itemData.last_estimate,
@@ -43,7 +45,7 @@ export default function List({ token }) {
         db.collection(token)
           .doc(id)
           .update({
-            last_purchased: currentTimeInDays,
+            last_purchased: currentTimeInMilliseconds,
             times_purchased: itemData.times_purchased + 1,
             last_estimate: latestEstimate,
           });
@@ -52,8 +54,10 @@ export default function List({ token }) {
   };
 
   function compareTimeStamps(lastPurchased) {
-    const currentTimeInDays = Math.floor(Date.now() / 86400000);
-    return currentTimeInDays - lastPurchased < 1;
+    // currentTimeInMilliseconds is used to compare the last_purchased property and make sure that it is less a day in milliseconds
+    const currentTimeInMilliseconds = Date.now();
+    const oneDayInMilliseconds = 86400000;
+    return currentTimeInMilliseconds - lastPurchased < oneDayInMilliseconds;
   }
 
   const alphabetizeListItems = (list) => {

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -65,7 +65,7 @@ export default function List({ token }) {
 
   function compareTimeStamps(lastPurchased) {
     const currentTimestamp = Math.round(Date.now() / 86400000);
-    return currentTimestamp - lastPurchased < lastPurchased;
+    return currentTimestamp - lastPurchased < 1;
   }
 
   return (

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -90,10 +90,10 @@ export default function List({ token }) {
   const alphabetizeListItems = (list) => {
     // logic in here isn't checking for capitalization
     const sortedList = list.sort((a, b) => {
-      if (a.data().item_name < b.data().item_name) {
+      if (a.data().item_name.toLowerCase() < b.data().item_name.toLowerCase()) {
         return -1;
       }
-      if (a.data().item_name > b.data().item_name) {
+      if (a.data().item_name.toLowerCase() > b.data().item_name.toLowerCase()) {
         return 1;
       }
       return 0;

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { db } from '../lib/firebase';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import { useHistory } from 'react-router-dom';
@@ -14,19 +14,6 @@ export default function List({ token }) {
   function handleReset() {
     setQuery('');
   }
-
-  const alphabetizeListItems = (list) => {
-    const sortedList = list.sort((a, b) => {
-      if (a.data().item_name < b.data().item_name) {
-        return -1;
-      }
-      if (a.data().item_name > b.data().item_name) {
-        return 1;
-      }
-      return 0;
-    });
-    return sortedList;
-  };
 
   const markItemPurchased = (e, id, itemData) => {
     const currentTimestamp = Math.round(Date.now() / 86400000);
@@ -67,6 +54,19 @@ export default function List({ token }) {
     const currentTimestamp = Math.round(Date.now() / 86400000);
     return currentTimestamp - lastPurchased < 1;
   }
+
+  const alphabetizeListItems = (list) => {
+    const sortedList = list.sort((a, b) => {
+      if (a.data().item_name < b.data().item_name) {
+        return -1;
+      }
+      if (a.data().item_name > b.data().item_name) {
+        return 1;
+      }
+      return 0;
+    });
+    return sortedList;
+  };
 
   return (
     <>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -182,18 +182,22 @@ export default function List({ token }) {
                     className="checkbox-wrapper"
                     style={{ color: 'green', fontSize: '1.25rem' }}
                   >
-                    <input
-                      type="checkbox"
-                      aria-label={doc.data().item_name}
-                      aria-required="true"
-                      id={`grocery-item${++index}`}
-                      defaultChecked={compareTimeStamps(
-                        doc.data().last_purchased,
-                      )}
-                      disabled={compareTimeStamps(doc.data().last_purchased)}
-                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                    />
-                    {doc.data().item_name}
+                    <label>
+                      <input
+                        type="checkbox"
+                        // aria-label={doc.data().item_name}
+                        // aria-required="true"
+                        id={`grocery-item${++index}`}
+                        defaultChecked={compareTimeStamps(
+                          doc.data().last_purchased,
+                        )}
+                        disabled={compareTimeStamps(doc.data().last_purchased)}
+                        onClick={(e) =>
+                          markItemPurchased(e, doc.id, doc.data())
+                        }
+                      />
+                      {doc.data().item_name}
+                    </label>
                   </li>
                 ))}
 
@@ -223,18 +227,22 @@ export default function List({ token }) {
                     className="checkbox-wrapper"
                     style={{ color: 'purple', fontSize: '1.25rem' }}
                   >
-                    <input
-                      type="checkbox"
-                      aria-label={doc.data().item_name}
-                      aria-required="true"
-                      id={`grocery-item${++index}`}
-                      defaultChecked={compareTimeStamps(
-                        doc.data().last_purchased,
-                      )}
-                      disabled={compareTimeStamps(doc.data().last_purchased)}
-                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                    />
-                    {doc.data().item_name}
+                    <label>
+                      <input
+                        type="checkbox"
+                        // aria-label={doc.data().item_name}
+                        // aria-required="true"
+                        id={`grocery-item${++index}`}
+                        defaultChecked={compareTimeStamps(
+                          doc.data().last_purchased,
+                        )}
+                        disabled={compareTimeStamps(doc.data().last_purchased)}
+                        onClick={(e) =>
+                          markItemPurchased(e, doc.id, doc.data())
+                        }
+                      />
+                      {doc.data().item_name}
+                    </label>
                   </li>
                 ))}
 
@@ -263,18 +271,22 @@ export default function List({ token }) {
                     className="checkbox-wrapper"
                     style={{ color: 'red', fontSize: '1.25rem' }}
                   >
-                    <input
-                      type="checkbox"
-                      aria-label={doc.data().item_name}
-                      aria-required="true"
-                      id={`grocery-item${++index}`}
-                      defaultChecked={compareTimeStamps(
-                        doc.data().last_purchased,
-                      )}
-                      disabled={compareTimeStamps(doc.data().last_purchased)}
-                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                    />
-                    {doc.data().item_name}
+                    <label>
+                      <input
+                        type="checkbox"
+                        // aria-label={doc.data().item_name}
+                        // aria-required="true"
+                        id={`grocery-item${++index}`}
+                        defaultChecked={compareTimeStamps(
+                          doc.data().last_purchased,
+                        )}
+                        disabled={compareTimeStamps(doc.data().last_purchased)}
+                        onClick={(e) =>
+                          markItemPurchased(e, doc.id, doc.data())
+                        }
+                      />
+                      {doc.data().item_name}
+                    </label>
                   </li>
                 ))}
 
@@ -294,10 +306,10 @@ export default function List({ token }) {
                     className="checkbox-wrapper"
                     style={{ color: 'gray', fontSize: '1.25rem' }}
                   >
-                    <label htmlFor={`grocery-item${++index}`}>
+                    <label>
                       <input
                         type="checkbox"
-                        aria-label={doc.data().item_name}
+                        // aria-label={doc.data().item_name}
                         id={`grocery-item${++index}`}
                         defaultChecked={compareTimeStamps(
                           doc.data().last_purchased,

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -136,17 +136,16 @@ export default function List({ token }) {
     <>
       <h1>This Is Your Grocery List</h1>
       <h2>It uses the token: {token}</h2>
-      <label htmlFor="thesearch">
-        Search Grocery List Items
-        <input
-          type="text"
-          placeholder="enter grocery item"
-          value={query}
-          id="thesearch"
-          onChange={(e) => setQuery(e.target.value)}
-        />
-        <button onClick={handleReset}>Reset Text Field</button>
-      </label>
+      <label htmlFor="thesearch">Search Grocery List Items </label>
+      <input
+        type="text"
+        placeholder="enter grocery item"
+        value={query}
+        id="thesearch"
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <button onClick={handleReset}>Reset Text Field</button>
+
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Grocery List: Loading...</span>}
       {listItems && (

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -100,11 +100,11 @@ export default function List({ token }) {
     return sortedList;
   };
 
-  const checkForInactiveItem = (item) => {
+  const checkForInactiveItem = (itemData) => {
     // pass in the item and create a variable for item.data() here
-    const itemData = item.data();
+    const item = itemData.data();
 
-    if (itemData.times_purchased === 1) {
+    if (item.times_purchased === 1) {
       return true;
     }
 
@@ -119,9 +119,9 @@ export default function List({ token }) {
 
     // do the same conversion for last_purchased as lastPurchased
     const lastPurchasedToDays = Math.floor(
-      DateTime.fromISO(itemData.last_purchased).ts / millisecondsInADay,
+      DateTime.fromISO(item.last_purchased).ts / millisecondsInADay,
     );
-    const doubleLastEstimate = itemData.last_estimate * 2;
+    const doubleLastEstimate = item.last_estimate * 2;
     const timeEllapsed = nowInDays - lastPurchasedToDays;
 
     if (timeEllapsed > doubleLastEstimate) {

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -19,6 +19,7 @@ export default function List({ token }) {
   const markItemPurchased = (e, id, itemData) => {
     // use DateTime package to get current time
     const now = DateTime.now();
+
     // convert now to readable ISO string
     const nowToString = now.toString();
 

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -100,11 +100,29 @@ export default function List({ token }) {
   };
 
   const checkForInactiveItem = (item) => {
-    console.log(item);
     if (item.times_purchased === 1) {
       return true;
     }
 
+    // use DateTime package to get current time
+    const now = DateTime.now();
+
+    // initialize how many milliseconds there are in a day for calculation
+    const millisecondsInADay = 86400000;
+
+    // convert now to days
+    const nowInDays = Math.floor(now.ts / millisecondsInADay);
+
+    // do the same conversion for last_purchased as lastPurchased
+    const lastPurchasedToDays = Math.floor(
+      DateTime.fromISO(item.last_purchased).ts / millisecondsInADay,
+    );
+    const doubleLastEstimate = item.last_estimate * 2;
+    const timeEllapsed = nowInDays - lastPurchasedToDays;
+
+    if (timeEllapsed > doubleLastEstimate) {
+      return true;
+    }
     return false;
   };
 

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -88,7 +88,6 @@ export default function List({ token }) {
   }
 
   const alphabetizeListItems = (list) => {
-    // logic in here isn't checking for capitalization
     const sortedList = list.sort((a, b) => {
       if (a.data().item_name.toLowerCase() < b.data().item_name.toLowerCase()) {
         return -1;

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -16,7 +16,7 @@ export default function List({ token }) {
   }
 
   const markItemPurchased = (e, id, itemData) => {
-    const currentTimestamp = Math.round(Date.now() / 86400000);
+    const currentTimestamp = Math.floor(Date.now() / 86400000);
     const latestInterval = currentTimestamp - itemData.last_purchased;
 
     if (e.target.checked === true) {
@@ -51,7 +51,7 @@ export default function List({ token }) {
   };
 
   function compareTimeStamps(lastPurchased) {
-    const currentTimestamp = Math.round(Date.now() / 86400000);
+    const currentTimestamp = Math.floor(Date.now() / 86400000);
     return currentTimestamp - lastPurchased < 1;
   }
 
@@ -103,9 +103,118 @@ export default function List({ token }) {
                     doc.data().item_name.includes(query.toLowerCase().trim()) ||
                     query === '',
                 )
+                .filter((item) => item.data().last_estimate <= 7)
 
                 .map((doc, index) => (
-                  <li key={doc.id} className="checkbox-wrapper">
+                  <li
+                    key={doc.id}
+                    className="checkbox-wrapper"
+                    style={{ color: 'green', fontSize: '1.25rem' }}
+                  >
+                    <label htmlFor={`grocery-item${++index}`}>
+                      <input
+                        type="checkbox"
+                        id={`grocery-item${++index}`}
+                        defaultChecked={compareTimeStamps(
+                          doc.data().last_purchased,
+                        )}
+                        disabled={compareTimeStamps(doc.data().last_purchased)}
+                        onClick={(e) =>
+                          markItemPurchased(e, doc.id, doc.data())
+                        }
+                      />
+                      {doc.data().item_name}
+                    </label>
+                  </li>
+                ))}
+
+              {alphabetizeListItems(listItems.docs)
+                .filter(
+                  (doc) =>
+                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
+                    query === '',
+                )
+                .filter(
+                  (item) =>
+                    item.data().last_estimate > 7 &&
+                    item.data().last_estimate <= 30,
+                )
+
+                .map((doc, index) => (
+                  <li
+                    key={doc.id}
+                    className="checkbox-wrapper"
+                    style={{ color: 'purple', fontSize: '1.25rem' }}
+                  >
+                    <label htmlFor={`grocery-item${++index}`}>
+                      <input
+                        type="checkbox"
+                        id={`grocery-item${++index}`}
+                        defaultChecked={compareTimeStamps(
+                          doc.data().last_purchased,
+                        )}
+                        disabled={compareTimeStamps(doc.data().last_purchased)}
+                        onClick={(e) =>
+                          markItemPurchased(e, doc.id, doc.data())
+                        }
+                      />
+                      {doc.data().item_name}
+                    </label>
+                  </li>
+                ))}
+
+              {alphabetizeListItems(listItems.docs)
+                .filter(
+                  (doc) =>
+                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
+                    query === '',
+                )
+                .filter(
+                  (item) =>
+                    item.data().last_estimate > 30 &&
+                    item.data().last_estimate < item.data().last_estimate * 2,
+                )
+
+                .map((doc, index) => (
+                  <li
+                    key={doc.id}
+                    className="checkbox-wrapper"
+                    style={{ color: 'red', fontSize: '1.25rem' }}
+                  >
+                    <label htmlFor={`grocery-item${++index}`}>
+                      <input
+                        type="checkbox"
+                        id={`grocery-item${++index}`}
+                        defaultChecked={compareTimeStamps(
+                          doc.data().last_purchased,
+                        )}
+                        disabled={compareTimeStamps(doc.data().last_purchased)}
+                        onClick={(e) =>
+                          markItemPurchased(e, doc.id, doc.data())
+                        }
+                      />
+                      {doc.data().item_name}
+                    </label>
+                  </li>
+                ))}
+
+              {alphabetizeListItems(listItems.docs)
+                .filter(
+                  (doc) =>
+                    doc.data().item_name.includes(query.toLowerCase().trim()) ||
+                    query === '',
+                )
+                .filter(
+                  (item) =>
+                    item.data().last_estimate >= item.data().last_estimate * 2,
+                )
+
+                .map((doc, index) => (
+                  <li
+                    key={doc.id}
+                    className="checkbox-wrapper"
+                    style={{ color: 'gray', fontSize: '1.25rem' }}
+                  >
                     <label htmlFor={`grocery-item${++index}`}>
                       <input
                         type="checkbox"

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -88,6 +88,7 @@ export default function List({ token }) {
   }
 
   const alphabetizeListItems = (list) => {
+    // logic in here isn't checking for capitalization
     const sortedList = list.sort((a, b) => {
       if (a.data().item_name < b.data().item_name) {
         return -1;

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -17,6 +17,14 @@ export default function List({ token }) {
     setQuery('');
   }
 
+  const calculateLatestInterval = (lastPurchased, currentDateTime) => {
+    return Math.floor(
+      Interval.fromDateTimes(DateTime.fromISO(lastPurchased), currentDateTime)
+        .toDuration('days')
+        .toObject().days,
+    );
+  };
+
   const markItemPurchased = (e, id, itemData) => {
     const currentDateTime = DateTime.now();
 
@@ -33,13 +41,9 @@ export default function List({ token }) {
       } else {
         // if an item has at least 1 times_purchased, calculate the latestInterval with Interval from Luxon
         // and use the previous last_estimate property to update the database's last_estimate property with latestEstimate
-        const latestInterval = Math.floor(
-          Interval.fromDateTimes(
-            DateTime.fromISO(itemData.last_purchased),
-            currentDateTime,
-          )
-            .toDuration('days')
-            .toObject().days,
+        const latestInterval = calculateLatestInterval(
+          itemData.last_purchased,
+          currentDateTime,
         );
 
         const latestEstimate = calculateEstimate(

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -178,31 +178,24 @@ export default function List({ token }) {
                   }
                 })
 
-                .map((doc, index) => (
+                .map((doc) => (
                   <li
                     key={doc.id}
                     className="checkbox-wrapper"
-                    style={{ color: 'green', fontSize: '1.25rem' }}
+                    style={{ color: 'green' }}
                   >
-                    <label>
-                      <input
-                        type="checkbox"
-                        // aria-label={doc.data().item_name}
-                        // aria-required="true"
-                        id={`grocery-item${++index}`}
-                        defaultChecked={compareTimeStamps(
-                          doc.data().last_purchased,
-                        )}
-                        disabled={compareTimeStamps(doc.data().last_purchased)}
-                        onClick={(e) =>
-                          markItemPurchased(e, doc.id, doc.data())
-                        }
-                      />
-                      {doc.data().item_name}
-                    </label>
+                    <input
+                      type="checkbox"
+                      id={doc.id}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
+                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                    />
+                    <label htmlFor={doc.id}>{doc.data().item_name}</label>
                   </li>
                 ))}
-
               {alphabetizeListItems(listItems.docs)
                 .filter(
                   (doc) =>
@@ -223,28 +216,22 @@ export default function List({ token }) {
                   }
                 })
 
-                .map((doc, index) => (
+                .map((doc) => (
                   <li
                     key={doc.id}
                     className="checkbox-wrapper"
-                    style={{ color: 'purple', fontSize: '1.25rem' }}
+                    style={{ color: 'purple' }}
                   >
-                    <label>
-                      <input
-                        type="checkbox"
-                        // aria-label={doc.data().item_name}
-                        // aria-required="true"
-                        id={`grocery-item${++index}`}
-                        defaultChecked={compareTimeStamps(
-                          doc.data().last_purchased,
-                        )}
-                        disabled={compareTimeStamps(doc.data().last_purchased)}
-                        onClick={(e) =>
-                          markItemPurchased(e, doc.id, doc.data())
-                        }
-                      />
-                      {doc.data().item_name}
-                    </label>
+                    <input
+                      type="checkbox"
+                      id={doc.id}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
+                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                    />
+                    <label htmlFor={doc.id}>{doc.data().item_name}</label>
                   </li>
                 ))}
 
@@ -267,28 +254,22 @@ export default function List({ token }) {
                   }
                 })
 
-                .map((doc, index) => (
+                .map((doc) => (
                   <li
                     key={doc.id}
                     className="checkbox-wrapper"
-                    style={{ color: 'red', fontSize: '1.25rem' }}
+                    style={{ color: 'red' }}
                   >
-                    <label>
-                      <input
-                        type="checkbox"
-                        // aria-label={doc.data().item_name}
-                        // aria-required="true"
-                        id={`grocery-item${++index}`}
-                        defaultChecked={compareTimeStamps(
-                          doc.data().last_purchased,
-                        )}
-                        disabled={compareTimeStamps(doc.data().last_purchased)}
-                        onClick={(e) =>
-                          markItemPurchased(e, doc.id, doc.data())
-                        }
-                      />
-                      {doc.data().item_name}
-                    </label>
+                    <input
+                      type="checkbox"
+                      id={doc.id}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
+                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                    />
+                    <label htmlFor={doc.id}>{doc.data().item_name}</label>
                   </li>
                 ))}
 
@@ -302,27 +283,22 @@ export default function List({ token }) {
                 )
                 .filter((item) => checkForInactiveItem(item))
 
-                .map((doc, index) => (
+                .map((doc) => (
                   <li
                     key={doc.id}
                     className="checkbox-wrapper"
-                    style={{ color: 'gray', fontSize: '1.25rem' }}
+                    style={{ color: 'gray' }}
                   >
-                    <label>
-                      <input
-                        type="checkbox"
-                        // aria-label={doc.data().item_name}
-                        id={`grocery-item${++index}`}
-                        defaultChecked={compareTimeStamps(
-                          doc.data().last_purchased,
-                        )}
-                        disabled={compareTimeStamps(doc.data().last_purchased)}
-                        onClick={(e) =>
-                          markItemPurchased(e, doc.id, doc.data())
-                        }
-                      />
-                      {doc.data().item_name}
-                    </label>
+                    <input
+                      type="checkbox"
+                      id={doc.id}
+                      defaultChecked={compareTimeStamps(
+                        doc.data().last_purchased,
+                      )}
+                      disabled={compareTimeStamps(doc.data().last_purchased)}
+                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+                    />
+                    <label htmlFor={doc.id}>{doc.data().item_name}</label>
                   </li>
                 ))}
             </ul>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -122,6 +122,8 @@ export default function List({ token }) {
     const lastPurchasedToDays = Math.floor(
       DateTime.fromISO(item.last_purchased).ts / millisecondsInADay,
     );
+
+    // calculate if item last_purchase is over double since last_estimate
     const doubleLastEstimate = item.last_estimate * 2;
     const timeEllapsed = nowInDays - lastPurchasedToDays;
 

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -168,8 +168,8 @@ export default function List({ token }) {
                     return item.data().purchase_frequency === 7;
                   } else {
                     return (
-                      item.data().last_estimate <= 7 &&
-                      checkForInactiveItem(item)
+                      item.data().last_estimate < 7 &&
+                      !checkForInactiveItem(item.data())
                     );
                   }
                 })
@@ -208,9 +208,9 @@ export default function List({ token }) {
                     return item.data().purchase_frequency === 14;
                   } else {
                     return (
-                      item.data().last_estimate > 7 &&
-                      item.data().last_estimate <= 14 &&
-                      checkForInactiveItem(item)
+                      (item.data().last_estimate >= 7 ||
+                        item.data().last_estimate <= 30) &&
+                      !checkForInactiveItem(item.data())
                     );
                   }
                 })
@@ -249,8 +249,8 @@ export default function List({ token }) {
                     return item.data().purchase_frequency === 30;
                   } else {
                     return (
-                      item.data().last_estimate > 14 &&
-                      checkForInactiveItem(item)
+                      item.data().last_estimate > 30 &&
+                      !checkForInactiveItem(item.data())
                     );
                   }
                 })

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -162,11 +162,11 @@ export default function List({ token }) {
   };
 
   const filterByLessThanSevenDays = (listItems) => {
-    // filter the items by user input
-    const alphabetizedItems = filterByUserInput(listItems);
+    // filter the items by user input or render all items if no input
+    const alphabetizedUserInputOrAllItems = filterByUserInput(listItems);
 
     // filter into the green category of less than 7 days
-    return alphabetizedItems.filter((item) => {
+    return alphabetizedUserInputOrAllItems.filter((item) => {
       if (item.data().times_purchased === 0) {
         return item.data().purchase_frequency === 7;
       } else {
@@ -176,11 +176,11 @@ export default function List({ token }) {
   };
 
   const filterByMoreThanSevenDaysAndLessThanThirtyDays = (listItems) => {
-    // filter the items by user input
-    const alphabetizedItems = filterByUserInput(listItems);
+    // filter the items by user input or render all items if no input
+    const alphabetizedUserInputOrAllItems = filterByUserInput(listItems);
 
     // filter items into the purple category of more than 7 days and less than 30 days
-    return alphabetizedItems.filter((item) => {
+    return alphabetizedUserInputOrAllItems.filter((item) => {
       if (item.data().times_purchased === 0) {
         return item.data().purchase_frequency === 14;
       } else {
@@ -194,11 +194,11 @@ export default function List({ token }) {
   };
 
   const filterByMoreThanThirtyDays = (listItems) => {
-    // filter the items by user input
-    const alphabetizedItems = filterByUserInput(listItems);
+    // filter the items by user input or render all items if no input
+    const alphabetizedUserInputOrAllItems = filterByUserInput(listItems);
 
     // filter items into the red category of more than 30 days
-    return alphabetizedItems.filter((item) => {
+    return alphabetizedUserInputOrAllItems.filter((item) => {
       if (item.data().times_purchased === 0) {
         return item.data().purchase_frequency === 30;
       } else {
@@ -208,11 +208,31 @@ export default function List({ token }) {
   };
 
   const filterByInactiveItems = (listItems) => {
-    // filter the items by user input
-    const alphabetizedItems = filterByUserInput(listItems);
+    // filter the items by user input or render all items if no input
+    const alphabetizedUserInputOrAllItems = filterByUserInput(listItems);
 
     // filter items into the gray category of more than double last_estimate
-    return alphabetizedItems.filter((item) => checkForInactiveItem(item));
+    return alphabetizedUserInputOrAllItems.filter((item) =>
+      checkForInactiveItem(item),
+    );
+  };
+
+  const renderUnorderedList = (doc, color) => {
+    return (
+      <li key={doc.id} className="checkbox-wrapper" style={{ color: color }}>
+        <input
+          type="checkbox"
+          id={doc.id}
+          defaultChecked={compareTimeStamps(doc.data().last_purchased)}
+          disabled={compareTimeStamps(doc.data().last_purchased)}
+          onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
+        />
+        <label htmlFor={doc.id}>{doc.data().item_name}</label>
+        <button key={doc.id} onClick={() => deleteItem(doc.id)}>
+          Delete
+        </button>
+      </li>
+    );
   };
 
   return (
@@ -243,95 +263,21 @@ export default function List({ token }) {
             </section>
           ) : (
             <ul>
-              {filterByLessThanSevenDays(listItems).map((doc) => (
-                <li
-                  key={doc.id}
-                  className="checkbox-wrapper"
-                  style={{ color: 'green' }}
-                >
-                  <input
-                    type="checkbox"
-                    id={doc.id}
-                    defaultChecked={compareTimeStamps(
-                      doc.data().last_purchased,
-                    )}
-                    disabled={compareTimeStamps(doc.data().last_purchased)}
-                    onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                  />
-                  <label htmlFor={doc.id}>{doc.data().item_name}</label>
-                  <button key={doc.id} onClick={() => deleteItem(doc.id)}>
-                    Delete
-                  </button>
-                </li>
-              ))}
-
-              {filterByMoreThanSevenDaysAndLessThanThirtyDays(listItems).map(
-                (doc) => (
-                  <li
-                    key={doc.id}
-                    className="checkbox-wrapper"
-                    style={{ color: 'purple' }}
-                  >
-                    <input
-                      type="checkbox"
-                      id={doc.id}
-                      defaultChecked={compareTimeStamps(
-                        doc.data().last_purchased,
-                      )}
-                      disabled={compareTimeStamps(doc.data().last_purchased)}
-                      onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                    />
-                    <label htmlFor={doc.id}>{doc.data().item_name}</label>
-                    <button key={doc.id} onClick={() => deleteItem(doc.id)}>
-                      Delete
-                    </button>
-                  </li>
-                ),
+              {filterByLessThanSevenDays(listItems).map((doc) =>
+                renderUnorderedList(doc, 'green'),
               )}
 
-              {filterByMoreThanThirtyDays(listItems).map((doc) => (
-                <li
-                  key={doc.id}
-                  className="checkbox-wrapper"
-                  style={{ color: 'red' }}
-                >
-                  <input
-                    type="checkbox"
-                    id={doc.id}
-                    defaultChecked={compareTimeStamps(
-                      doc.data().last_purchased,
-                    )}
-                    disabled={compareTimeStamps(doc.data().last_purchased)}
-                    onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                  />
-                  <label htmlFor={doc.id}>{doc.data().item_name}</label>
-                  <button key={doc.id} onClick={() => deleteItem(doc.id)}>
-                    Delete
-                  </button>
-                </li>
-              ))}
+              {filterByMoreThanSevenDaysAndLessThanThirtyDays(
+                listItems,
+              ).map((doc) => renderUnorderedList(doc, 'purple'))}
 
-              {filterByInactiveItems(listItems).map((doc) => (
-                <li
-                  key={doc.id}
-                  className="checkbox-wrapper"
-                  style={{ color: 'gray' }}
-                >
-                  <input
-                    type="checkbox"
-                    id={doc.id}
-                    defaultChecked={compareTimeStamps(
-                      doc.data().last_purchased,
-                    )}
-                    disabled={compareTimeStamps(doc.data().last_purchased)}
-                    onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
-                  />
-                  <label htmlFor={doc.id}>{doc.data().item_name}</label>
-                  <button key={doc.id} onClick={() => deleteItem(doc.id)}>
-                    Delete
-                  </button>
-                </li>
-              ))}
+              {filterByMoreThanThirtyDays(listItems).map((doc) =>
+                renderUnorderedList(doc, 'red'),
+              )}
+
+              {filterByInactiveItems(listItems).map((doc) =>
+                renderUnorderedList(doc, 'gray'),
+              )}
             </ul>
           )}
         </>

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -68,6 +68,10 @@ export default function List({ token }) {
     return sortedList;
   };
 
+  const checkForInactiveItem = (item) =>
+    Math.floor(Date.now() / 86400000) - item.data().last_purchased <
+    item.data().last_estimate;
+
   return (
     <>
       <h1>This Is Your Grocery List</h1>
@@ -109,7 +113,10 @@ export default function List({ token }) {
                   if (item.data().times_purchased === 0) {
                     return item.data().purchase_frequency === 7;
                   } else {
-                    return item.data().last_estimate <= 7;
+                    return (
+                      item.data().last_estimate <= 7 &&
+                      checkForInactiveItem(item)
+                    );
                   }
                 })
 
@@ -150,7 +157,8 @@ export default function List({ token }) {
                   } else {
                     return (
                       item.data().last_estimate > 7 &&
-                      item.data().last_estimate <= 14
+                      item.data().last_estimate <= 14 &&
+                      checkForInactiveItem(item)
                     );
                   }
                 })
@@ -192,7 +200,7 @@ export default function List({ token }) {
                   } else {
                     return (
                       item.data().last_estimate > 14 &&
-                      item.data().last_estimate <= 30
+                      checkForInactiveItem(item)
                     );
                   }
                 })

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -100,6 +100,7 @@ export default function List({ token }) {
   };
 
   const checkForInactiveItem = (item) => {
+    // pass in the item and create a variable for item.data() here
     if (item.times_purchased === 1) {
       return true;
     }

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { db } from '../lib/firebase';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import { useHistory } from 'react-router-dom';
@@ -10,10 +10,28 @@ export default function List({ token }) {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
   const [query, setQuery] = useState('');
+  const [alphabetizedListItems, setAlphabetizedListItems] = useState([]);
 
   function handleReset() {
     setQuery('');
   }
+
+  useEffect(() => {
+    if (listItems) {
+      const abcListItems = listItems.docs.sort((a, b) => {
+        if (a.data().item_name < b.data().item_name) {
+          return -1;
+        }
+        if (a.data().item_name > b.data().item_name) {
+          return 1;
+        }
+        return 0;
+      });
+      setAlphabetizedListItems(abcListItems);
+    }
+  }, [setAlphabetizedListItems, listItems]);
+
+  // console.log(listItems.docs.map((doc) => doc.data().item_name));
 
   const markItemPurchased = (e, id, itemData) => {
     const currentTimestamp = Math.round(Date.now() / 86400000);

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -68,21 +68,15 @@ export default function List({ token }) {
     if (lastPurchased === null) {
       return false;
     }
-    // use DateTime package to get current time
-    const now = DateTime.now();
 
-    // initialize how many milliseconds there are in a day for calculation
-    const millisecondsInADay = 86400000;
-
-    // convert now to days
-    const nowInDays = Math.floor(now.ts / millisecondsInADay);
-
-    // do the same conversion for last_purchased as lastPurchased
-    const lastPurchasedToDays = Math.floor(
-      DateTime.fromISO(lastPurchased).ts / millisecondsInADay,
+    // determine the amount days between now and last_purchase
+    const currentDateTime = DateTime.now();
+    const latestInterval = calculateLatestInterval(
+      lastPurchased,
+      currentDateTime,
     );
 
-    return nowInDays - lastPurchasedToDays === 0;
+    return latestInterval === 0;
   }
 
   const checkForInactiveItem = (itemData) => {
@@ -93,25 +87,15 @@ export default function List({ token }) {
       return true;
     }
 
-    // use DateTime package to get current time
-    const now = DateTime.now();
-
-    // initialize how many milliseconds there are in a day for calculation
-    const millisecondsInADay = 86400000;
-
-    // convert now to days
-    const nowInDays = Math.floor(now.ts / millisecondsInADay);
-
-    // do the same conversion for last_purchased as lastPurchased
-    const lastPurchasedToDays = Math.floor(
-      DateTime.fromISO(item.last_purchased).ts / millisecondsInADay,
+    // calculate if the duration between now and last_purchased is greater than DOUBLE the last_estimate
+    const doubleLastEstimate = item.last_estimate * 2;
+    const currentDateTime = DateTime.now();
+    const latestInterval = calculateLatestInterval(
+      itemData.last_purchased,
+      currentDateTime,
     );
 
-    // calculate if item last_purchase is over double since last_estimate
-    const doubleLastEstimate = item.last_estimate * 2;
-    const timeEllapsed = nowInDays - lastPurchasedToDays;
-
-    if (timeEllapsed > doubleLastEstimate) {
+    if (latestInterval > doubleLastEstimate) {
       return true;
     }
     return false;

--- a/src/pages/List.js
+++ b/src/pages/List.js
@@ -167,6 +167,7 @@ export default function List({ token }) {
                       .item_name.toLowerCase()
                       .includes(query.toLowerCase().trim()) || query === '',
                 )
+                // filter items that have a last_estimate of less than 7 days
                 .filter((item) => {
                   if (item.data().times_purchased === 0) {
                     return item.data().purchase_frequency === 7;
@@ -204,6 +205,7 @@ export default function List({ token }) {
                       .item_name.toLowerCase()
                       .includes(query.toLowerCase().trim()) || query === '',
                 )
+                // filter items that have have a last_estimate between 7 or more and 30 or less days
                 .filter((item) => {
                   if (item.data().times_purchased === 0) {
                     return item.data().purchase_frequency === 14;
@@ -243,6 +245,7 @@ export default function List({ token }) {
                       .item_name.toLowerCase()
                       .includes(query.toLowerCase().trim()) || query === '',
                 )
+                // filter items that have a last_estimate of more than 30 days
                 .filter((item) => {
                   if (item.data().times_purchased === 0) {
                     return item.data().purchase_frequency === 30;
@@ -281,6 +284,7 @@ export default function List({ token }) {
                       .item_name.toLowerCase()
                       .includes(query.toLowerCase().trim()) || query === '',
                 )
+                // filter items that return true from checkForInactiveItem()
                 .filter((item) => checkForInactiveItem(item))
 
                 .map((doc) => (


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

We added functionality in `List.js` so it can filter list items alphabetically. It can also move an item into one of 4 different lists based on how often it is purchased. The 4 groupings are:
- 0 to 7 days
- 7 to 30 days
- 30+ days
- undefined
The current approach is functional, but would likely benefit from additional refactoring since the `List.js` file is getting quite lengthy. UPDATE May 16, 2021 - some refactoring has occurred! 

To test for accessibility, we used [WebAIM WAVE](https://reactjs.org/docs/accessibility.html#webaim-wave) as a Chrome extension, as well as the VoiceOver option available on Mac.


## Related Issue

closes #13 
closes #29 

## Acceptance Criteria

- [x]  Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive

- [x]  Items should be sorted by the estimated number of days until next purchase
- [x]  Items with the same number of estimated days until next purchase should be sorted alphabetically
- [x]  **Items in the different states should be described distinctly when read by a screen reader WORKING!**

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|  ✓ | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Notes
- We have successfully implemented SOME accessibilty features with `aria-label`. But I think I realized that we shouldn't use `aria-label={`grocery-item${++index}`}` and `id={`grocery-item${++index}`}` because the screen reader is reading the index, not the same. So maybe something like `aria-label={item.data().item_name}` and `id={item.data().item_name}` makes more sense? We will have to test it to be sure of course!

UPDATE as of May 16, 2021: `aria-label` removed. It was unnecessary for this project at this time in assisting the screen reader.

- I would love to create something similar to our helper function `alphabetizeListItems()` that we can re-use for rendering the various list items by their suggested purchase time. Something like `filterItemsByLastEstimate()`. But I need help and guidance with this one.
- Also, we have added a few different conditionals that allow the items to be properly sorted. But, it feels like there HAS to be a better way!
UPDATE May 16, 2021: A better way was found! See bottom of PR.


### Before
Items were listed in a seemingly random order. When the user entered an item into the list, there was no visual showing which grouping it had been put into.

<img width="566" alt="frequencyItemsBefore" src="https://user-images.githubusercontent.com/38255956/117916746-5fb95580-b2ad-11eb-9bc2-b21e8cffac46.png">


### After
Items are now grouped based on frequency of purchase. Within each grouping, items are listed alphabetically.
<img width="604" alt="frequencyItemsAfter" src="https://user-images.githubusercontent.com/38255956/117916777-6d6edb00-b2ad-11eb-8dc4-37838615c114.png">



## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

1. On `main` run `git pull`
2. Run `git checkout jr-jw-list-items-by-frequency`
2. Run `npm install`
3. Run `npm start`
4. Once you are at `https://localhost:3000`, clear any existing tokens from your `local storage`. The screenshot below can assist you in clearing any tokens when using Chrome as your browser. 
<img width="568" alt="clearLocalStorage" src="https://user-images.githubusercontent.com/38255956/117917455-c4c17b00-b2ae-11eb-909c-4a3c27d2961f.png">

5. Once you are on the main page, it is advised to create your own new token, and to add a few items to each of the 3 categories - `soon (0-7)`, `kind of soon (8-30)`, `not that soon (30+)`. Don't forget to include capitalization and punctuation as well with the grocery list items you add.

6. Once you have created a grocery list with various items in the green (0-7), purple (8-30) and red (30+) day categories, you will see that items in each grouping are alphabetized. Items with a checkmark that are gray are considered `inactive` and have been purchased in the last 24 hours, or have exceeded their assumed time frame of when they would be purchased again. 

7. We used the native VoiceOver function on a 2018 MacBook Air, running macOS Big Sur, Version 11.3.1 to test the screen reader. The following are directions to use that screen reader:
- `command` + `spacebar`
- type `accessibility`, `enter`
- make sure that `VoiceOver` is highlighted (as seen below)
<img width="664" alt="accessibilityScreenReader" src="https://user-images.githubusercontent.com/38255956/118429337-12672a80-b697-11eb-8e81-0ce1ddb3f027.png">

- click the box for `Enable VoiceOver` 
- begin navigating the Grocery List application. It is recommended to use `tab`, `enter`, and the arrow keys to navigate the fields on the screen. 
- when done, you can turn off the screen reader by clicking the `X` in the upper left corner of the gray VoiceOver box.
<img width="601" alt="voiceOverBox" src="https://user-images.githubusercontent.com/38255956/118429492-6eca4a00-b697-11eb-96c0-c70e98fa9c22.png">




# FINAL UPDATES

I have addressed ALL the AC and everything is working as intended. The only thing I have NOT completed is refactoring the WET code to be more DRY with a switch statement or anything like that. 

Check out the screen shots to see that everything is rendering on the screen correctly, still alphabetized, even if some of the items are capitalized, and that the items become inactive under the AC's stated conditions.

![color-coded-list](https://user-images.githubusercontent.com/47455758/118425027-f0b57580-b68d-11eb-9ed4-c4ff2031767c.jpg)

![inactive-list](https://user-images.githubusercontent.com/47455758/118425042-f57a2980-b68d-11eb-8a6b-702e67e81d5d.jpg)

![firebase-utc](https://user-images.githubusercontent.com/47455758/118425058-ff039180-b68d-11eb-8d39-fd09fc28dab0.jpg)

Okay Friends, I have updated A LOT of the codebase here. The main thing that I did was to break down and use a package for DateTime called Luxon https://moment.github.io/luxon/docs/manual/tour.html 

If you look at the Firebase screen shot above, I've underscored in pink the new UTC DateTime format. Apparently, this is the industry standard way to store times in databases. Luxon gives us a ton of ways to work with their DateTime object, and this one is achieved by `.toString()`. 

```javascript
// use DateTime package to get current time
const now = DateTime.now();

// convert now to readable ISO string
const nowToString = now.toString();
```

I am still storing the `last_estimate` as an integer representing days, which is total milliseconds divided by `const millisecondsInADay = 86400000;` 

```javascript
// because last_estimate is an integer representing days, convert now to days
const nowInDays = Math.floor(now.ts / millisecondsInADay);

// do the same conversion for last_purchased
const lastPurchasedToDays = Math.floor(
   DateTime.fromISO(itemData.last_purchased).ts / millisecondsInADay,
);
```

So now we have a more readable timestamp in the database, and still able to compare last_estimate by days.

`compareTimeStamp()`, which determines whether or not a checkmark stays checked or not is completely revamped:

```javascript
 function compareTimeStamps(lastPurchased) {
    // first check to see if lastPurchased === null in database
    if (lastPurchased === null) {
      return false;
    }
    // use DateTime package to get current time
    const now = DateTime.now();

    // initialize how many milliseconds there are in a day for calculation
    const millisecondsInADay = 86400000;

    // convert now to days
    const nowInDays = Math.floor(now.ts / millisecondsInADay);

    // do the same conversion for last_purchased as lastPurchased
    const lastPurchasedToDays = Math.floor(
      DateTime.fromISO(lastPurchased).ts / millisecondsInADay,
    );

    return nowInDays - lastPurchasedToDays === 0;
}
```

An item in the database which is less than 24 hours old will remain checked, but now it's MUCH easier to follow the logic in the function and the properties in Firestore

Another feature I successfully implemented is the accessibility/screen-reader working correctly. Instead of using `aria-label`, I opted for `<label>`. I still have FOUR different filters and maps, but here is an example of one of them:

```javascript
.map((doc) => (
   <li
     key={doc.id}
     className="checkbox-wrapper"
    style={{ color: 'green' }}
  >
    <input
      type="checkbox"
      id={doc.id}
      defaultChecked={compareTimeStamps(
        doc.data().last_purchased,
      )}
      disabled={compareTimeStamps(doc.data().last_purchased)}
        onClick={(e) => markItemPurchased(e, doc.id, doc.data())}
    />
   <label htmlFor={doc.id}>{doc.data().item_name}</label>
  </li>
))}
```
I updated the id to use `id={doc.id}` mirrored by the `htmlFor={doc.id}`. And now the screen reader knows which check box to associate with which `{doc.data().item_name}`.

# Conclusion

I think we are good to go to merge. Please let me know if you see anything I can fix/update! If you test this branch with the live Github link, make sure to start with a new token so the data in Firestore is not stale. 

I have added a ton of comments that I hope clarify the code, but if there isn't anything you don't understand, let me know!
