### PR TITLE
Update purchase frequency to use radio buttons

### DIFF
--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -74,7 +74,9 @@ export default function AddItem({ token }) {
 
   return (
     <>
-      <h1 className="my-5 text-3xl self-start font-light">Add New Item</h1>
+      <h1 className="mt-5 mb-10 text-3xl self-start font-light">
+        Add New Item
+      </h1>
       <form
         onSubmit={createListItem}
         className="flex flex-col items-center w-full"
@@ -111,7 +113,7 @@ export default function AddItem({ token }) {
               name="frequency"
               id="soon"
               value={7}
-              className="mr-5"
+              className="mx-5"
               onChange={handleFrequencyChange}
             />
             <label htmlFor="soon" className="text-midnight-green text-xl">
@@ -138,7 +140,7 @@ export default function AddItem({ token }) {
               name="frequency"
               id="soon"
               value={14}
-              className="mr-5"
+              className="mx-5"
               onChange={handleFrequencyChange}
             />
             <label htmlFor="soon" className="text-midnight-green text-xl">
@@ -147,7 +149,7 @@ export default function AddItem({ token }) {
           </div>
         </div>
 
-        <div className="flex items-center w-full mb-5">
+        <div className="flex items-center w-full mb-10">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="h-10 w-10 mr-5 fill-current text-paradise-pink"
@@ -165,7 +167,7 @@ export default function AddItem({ token }) {
               name="frequency"
               id="soon"
               value={30}
-              className="mr-5"
+              className="mx-5"
               onChange={handleFrequencyChange}
             />
             <label htmlFor="soon" className="text-midnight-green text-xl">

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -89,15 +89,75 @@ export default function AddItem({ token }) {
             onChange={handleNameChange}
           />
         </label>
-        <br />
-        <label className="mb-5">
-          Purchase Frequency
-          <select onBlur={handleFrequencyChange}>
+        <h2 className="my-5 self-start text-xl font-light">
+          When will you purchase it?
+        </h2>
+
+        <div className="flex items-center w-full mb-5">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-10 w-10 mr-5 fill-current text-caribbean-green"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <div className="flex items-center p-2 bg-gray-200 rounded w-full">
+            <input type="radio" name="frequency" id="soon" className="mr-5" />
+            <label htmlFor="soon" className="text-midnight-green text-xl">
+              Soon
+            </label>
+          </div>
+        </div>
+
+        <div className="flex items-center w-full mb-5">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-10 w-10 mr-5 fill-current text-orange-yellow"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <div className="flex items-center p-2 bg-gray-200 rounded w-full">
+            <input type="radio" name="frequency" id="soon" className="mr-5" />
+            <label htmlFor="soon" className="text-midnight-green text-xl">
+              Soonish
+            </label>
+          </div>
+        </div>
+
+        <div className="flex items-center w-full mb-5">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-10 w-10 mr-5 fill-current text-paradise-pink"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <div className="flex items-center p-2 bg-gray-200 rounded w-full">
+            <input type="radio" name="frequency" id="soon" className="mr-5" />
+            <label htmlFor="soon" className="text-midnight-green text-xl">
+              Not soon
+            </label>
+          </div>
+        </div>
+
+        {/* <select onBlur={handleFrequencyChange}>
             <option value={7}>Soon</option>
             <option value={14}>Kind of Soon</option>
             <option value={30}>Not Soon</option>
-          </select>
-        </label>
+          </select> */}
         <Button type="submit" text="+ Add a new item" />
       </form>
     </>

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -113,7 +113,7 @@ export default function AddItem({ token }) {
               name="frequency"
               id="soon"
               value={7}
-              className="mx-5"
+              className="h-5 w-5 mx-5"
               onChange={handleFrequencyChange}
             />
             <label htmlFor="soon" className="text-midnight-green text-xl">
@@ -140,7 +140,7 @@ export default function AddItem({ token }) {
               name="frequency"
               id="soon"
               value={14}
-              className="mx-5"
+              className="h-5 w-5 mx-5"
               onChange={handleFrequencyChange}
             />
             <label htmlFor="soon" className="text-midnight-green text-xl">
@@ -167,7 +167,7 @@ export default function AddItem({ token }) {
               name="frequency"
               id="soon"
               value={30}
-              className="mx-5"
+              className="h-5 w-5 mx-5"
               onChange={handleFrequencyChange}
             />
             <label htmlFor="soon" className="text-midnight-green text-xl">

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -91,7 +91,7 @@ export default function AddItem({ token }) {
             onChange={handleNameChange}
           />
         </label>
-        <h2 className="my-5 self-start text-xl font-light">
+        <h2 className="mt-10 mb-5 self-start text-xl font-light">
           When will you purchase it?
         </h2>
 

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -7,7 +7,7 @@ import Button from '../components/Button';
 
 export default function AddItem({ token }) {
   const [itemName, setItemName] = useState('');
-  const [purchaseFrequency, setPurchaseFrequency] = useState(7);
+  const [purchaseFrequency, setPurchaseFrequency] = useState(null);
 
   const [listItems] = useCollection(db.collection(token), {
     snapshotListenOptions: { includeMetadataChanges: true },
@@ -60,10 +60,10 @@ export default function AddItem({ token }) {
         ).toUpperCase()} is already in your list`,
         icon: 'error',
       });
-    } else if (!itemName) {
+    } else if (!itemName || !purchaseFrequency) {
       Swal.fire({
         title: 'UH OH!',
-        text: "Item name can't be blank",
+        text: 'Must have an item name and purchase frequency',
         icon: 'warning',
       });
     } else {
@@ -113,6 +113,7 @@ export default function AddItem({ token }) {
               name="frequency"
               id="soon"
               value={7}
+              // defaultChecked
               className="h-5 w-5 mx-5"
               onChange={handleFrequencyChange}
             />
@@ -138,12 +139,12 @@ export default function AddItem({ token }) {
             <input
               type="radio"
               name="frequency"
-              id="soon"
+              id="soonish"
               value={14}
               className="h-5 w-5 mx-5"
               onChange={handleFrequencyChange}
             />
-            <label htmlFor="soon" className="text-midnight-green text-xl">
+            <label htmlFor="soonish" className="text-midnight-green text-xl">
               Soonish
             </label>
           </div>
@@ -165,12 +166,12 @@ export default function AddItem({ token }) {
             <input
               type="radio"
               name="frequency"
-              id="soon"
+              id="not soon"
               value={30}
               className="h-5 w-5 mx-5"
               onChange={handleFrequencyChange}
             />
-            <label htmlFor="soon" className="text-midnight-green text-xl">
+            <label htmlFor="not soon" className="text-midnight-green text-xl">
               Not soon
             </label>
           </div>

--- a/src/pages/AddItem.js
+++ b/src/pages/AddItem.js
@@ -74,7 +74,7 @@ export default function AddItem({ token }) {
 
   return (
     <>
-      <h1>Add Item</h1>
+      <h1 className="my-5 text-3xl self-start font-light">Add New Item</h1>
       <form
         onSubmit={createListItem}
         className="flex flex-col items-center w-full"
@@ -106,7 +106,14 @@ export default function AddItem({ token }) {
             />
           </svg>
           <div className="flex items-center p-2 bg-gray-200 rounded w-full">
-            <input type="radio" name="frequency" id="soon" className="mr-5" />
+            <input
+              type="radio"
+              name="frequency"
+              id="soon"
+              value={7}
+              className="mr-5"
+              onChange={handleFrequencyChange}
+            />
             <label htmlFor="soon" className="text-midnight-green text-xl">
               Soon
             </label>
@@ -126,7 +133,14 @@ export default function AddItem({ token }) {
             />
           </svg>
           <div className="flex items-center p-2 bg-gray-200 rounded w-full">
-            <input type="radio" name="frequency" id="soon" className="mr-5" />
+            <input
+              type="radio"
+              name="frequency"
+              id="soon"
+              value={14}
+              className="mr-5"
+              onChange={handleFrequencyChange}
+            />
             <label htmlFor="soon" className="text-midnight-green text-xl">
               Soonish
             </label>
@@ -146,18 +160,19 @@ export default function AddItem({ token }) {
             />
           </svg>
           <div className="flex items-center p-2 bg-gray-200 rounded w-full">
-            <input type="radio" name="frequency" id="soon" className="mr-5" />
+            <input
+              type="radio"
+              name="frequency"
+              id="soon"
+              value={30}
+              className="mr-5"
+              onChange={handleFrequencyChange}
+            />
             <label htmlFor="soon" className="text-midnight-green text-xl">
               Not soon
             </label>
           </div>
         </div>
-
-        {/* <select onBlur={handleFrequencyChange}>
-            <option value={7}>Soon</option>
-            <option value={14}>Kind of Soon</option>
-            <option value={30}>Not Soon</option>
-          </select> */}
         <Button type="submit" text="+ Add a new item" />
       </form>
     </>


### PR DESCRIPTION
## Description

Refactors the purchase frequency to use radio buttons instead of a drop down select, to better match our Figma design.

## Related Issue

Closes #32 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|  ✓ | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

The main bulk of the work was creating the Tailwind utility classes and wrapping each clock SVG, input type radio and label in divs to be able to lay out each option as visually identical to our [Figma design](https://www.figma.com/file/Gd4a2z8c5iNG6b3ZWs36g4/Smart-Shopping-List?node-id=0%3A1) as possible.

1. Uses radio buttons instead of check boxes because radio buttons are more semantically correct in this situation when only one option is required. Updated the stylings with Tailwind utility classes to make each radio button look like our Figma design:

2. Includes Heroicon clock icon SVG as JSX next to each radio input type.

3. Refactored `purchaseFrequency` to have an initial state of `null`
```javascript
const [purchaseFrequency, setPurchaseFrequency] = useState(null);
```

4. Refactored the Sweet Alert to alert the user if they forgot to select a radio button purchase frequency.
```javascript 
} else if (!itemName || !purchaseFrequency) {
  Swal.fire({
    title: 'UH OH!',
    text: 'Must have an item name and purchase frequency',
    icon: 'warning',
  });
```


### Visual Changes

| | Before | After |
| --- | --- | --- |
| Mobile Nav |![mobile-add-item-before](https://user-images.githubusercontent.com/47455758/119577486-5b4a6d80-bd80-11eb-94d8-2b25e46f0645.jpg)| ![mobile-add-item-after](https://user-images.githubusercontent.com/47455758/119577498-600f2180-bd80-11eb-964f-41370e16e3c9.jpg)|
| Desktop |![desktop-add-item-before](https://user-images.githubusercontent.com/47455758/119577409-3524cd80-bd80-11eb-8852-ca8dc2c62cce.jpg) | ![desktop-add-item-after](https://user-images.githubusercontent.com/47455758/119577419-39e98180-bd80-11eb-85e7-3ca07550c42e.jpg)|

Sweet Alert activates if one of the purchase frequencies is not selected.
![new-sweet-alert-add-item](https://user-images.githubusercontent.com/47455758/119578411-1a535880-bd82-11eb-8f92-8a55e6cbda6e.jpg)

## Testing Steps / QA Criteria

1. On `main` run `git pull`
2. Run `git checkout update-purchase-frequency-checkboxes`
3. Run `npm install`
4. Run `npm start`
5. Notice the new radio buttons and how you can use your keyboard to tab to them, and then your arrow keys to move up and down to select which one you prefer.

